### PR TITLE
feat(ci): add weekly scheduled wheel build matrix

### DIFF
--- a/.github/scripts/check_for_releases.sh
+++ b/.github/scripts/check_for_releases.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -eo pipefail
+
+UPSTREAM_REPO="${UPSTREAM_REPO:?UPSTREAM_REPO must be set, e.g. state-spaces/mamba}"
+LIMIT="${LIMIT:-3}"
+OUTPUT_FILE="${OUTPUT_FILE:-releases.json}"
+
+echo "Fetching last ${LIMIT} stable releases of ${UPSTREAM_REPO}..."
+echo "---------------------------------------------------------------------"
+
+gh release list \
+  --repo "$UPSTREAM_REPO" \
+  --limit "$LIMIT" \
+  --exclude-drafts \
+  --exclude-pre-releases \
+  --json tagName \
+  --jq '[.[].tagName]' \
+  > "$OUTPUT_FILE"
+
+echo "Resolved release tags:"
+cat "$OUTPUT_FILE"
+echo
+echo "---"
+echo "Check complete."

--- a/.github/workflows/_build_in_container.yml
+++ b/.github/workflows/_build_in_container.yml
@@ -39,11 +39,11 @@ jobs:
           root-reserve-mb: 5120
           temp-reserve-mb: 32
           swap-size-mb: 10240
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
-          build-mount-path: '/var/lib/docker/'
+          remove-dotnet: "true"
+          remove-android: "true"
+          remove-haskell: "true"
+          remove-codeql: "true"
+          build-mount-path: "/var/lib/docker/"
 
       - name: Restore /var/lib/docker/
         run: sudo sh -c "mv ${GITHUB_WORKSPACE}/docker/* /var/lib/docker"
@@ -63,9 +63,9 @@ jobs:
         run: |
           echo "Free space:"
           df -h
-  
+
       - name: Pull the container
-        run: docker pull ${{ inputs.container-image }} 
+        run: docker pull ${{ inputs.container-image }}
 
       - name: Set CUDA and PyTorch versions
         run: |
@@ -94,7 +94,7 @@ jobs:
 
       - name: Build wheel
         id: build_wheel
-        env: 
+        env:
           CXX11_ABI: ${{ env.CXX11_ABI }}
           MATRIX_TORCH_VERSION: ${{ env.MATRIX_TORCH_VERSION}}
           WHEEL_CUDA_VERSION: ${{ env.WHEEL_CUDA_VERSION }}
@@ -106,6 +106,7 @@ jobs:
             --workdir /workspace \
             --volume $(pwd):/workspace \
             --volume $GITHUB_ENV:$GITHUB_ENV \
+            -e PIP_CONSTRAINT= \
             -e GITHUB_ENV=$GITHUB_ENV \
             -e CXX11_ABI=$CXX11_ABI \
             -e MATRIX_TORCH_VERSION=$MATRIX_TORCH_VERSION \

--- a/.github/workflows/_build_in_container.yml
+++ b/.github/workflows/_build_in_container.yml
@@ -53,7 +53,10 @@ jobs:
           build-mount-path: "/var/lib/"
 
       - name: Restore /var/lib/containerd/
-        run: sudo sh -c "mv ${GITHUB_WORKSPACE}/docker/* /var/lib"
+        run: sudo sh -c "mv ${GITHUB_WORKSPACE}/docker/containerd/* /var/lib/containerd"
+
+      - name: Restore /var/lib/docker/
+        run: sudo sh -c "mv ${GITHUB_WORKSPACE}/docker/docker/* /var/lib/docker"
 
       - name: Checkout source
         uses: actions/checkout@v4

--- a/.github/workflows/_build_in_container.yml
+++ b/.github/workflows/_build_in_container.yml
@@ -46,7 +46,7 @@ jobs:
           build-mount-path: "/var/lib/containerd/"
 
       - name: Restore /var/lib/containerd/
-        run: sudo sh -c "mv ${GITHUB_WORKSPACE}/docker/* /var/lib/docker"
+        run: sudo sh -c "mv ${GITHUB_WORKSPACE}/docker/* /var/lib/containerd"
 
       - name: Checkout source
         uses: actions/checkout@v4

--- a/.github/workflows/_build_in_container.yml
+++ b/.github/workflows/_build_in_container.yml
@@ -31,10 +31,14 @@ jobs:
     name: Build wheel (${{ inputs.container-image }})
     steps:
       - name: Move /var/lib/containerd/
-        run: sudo mv /var/lib/containerd/ "${GITHUB_WORKSPACE}/docker/containerd"
+        run: |
+          mkdir -p "${GITHUB_WORKSPACE}/docker/containerd"
+          sudo mv /var/lib/containerd/ "${GITHUB_WORKSPACE}/docker/containerd"
 
       - name: Move /var/lib/containerd/
-        run: sudo mv /var/lib/docker/ "${GITHUB_WORKSPACE}/docker/docker"
+        run: |
+          mkdir -p "${GITHUB_WORKSPACE}/docker/docker"
+          sudo mv /var/lib/docker/ "${GITHUB_WORKSPACE}/docker/docker"
 
       - name: Maximize build space
         uses: easimon/maximize-build-space@master

--- a/.github/workflows/_build_in_container.yml
+++ b/.github/workflows/_build_in_container.yml
@@ -30,8 +30,8 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     name: Build wheel (${{ inputs.container-image }})
     steps:
-      - name: Move /var/lib/containerd/
-        run: sudo mv /var/lib/containerd/ "${GITHUB_WORKSPACE}/docker"
+      - name: Move /var/lib/
+        run: sudo mv /var/lib/ "${GITHUB_WORKSPACE}/docker"
 
       - name: Maximize build space
         uses: easimon/maximize-build-space@master
@@ -43,10 +43,10 @@ jobs:
           remove-android: "true"
           remove-haskell: "true"
           remove-codeql: "true"
-          build-mount-path: "/var/lib/containerd/"
+          build-mount-path: "/var/lib/"
 
       - name: Restore /var/lib/containerd/
-        run: sudo sh -c "mv ${GITHUB_WORKSPACE}/docker/* /var/lib/containerd"
+        run: sudo sh -c "mv ${GITHUB_WORKSPACE}/docker/* /var/lib"
 
       - name: Checkout source
         uses: actions/checkout@v4

--- a/.github/workflows/_build_in_container.yml
+++ b/.github/workflows/_build_in_container.yml
@@ -30,8 +30,8 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     name: Build wheel (${{ inputs.container-image }})
     steps:
-      - name: Move /var/lib/docker/
-        run: sudo mv /var/lib/docker/ "${GITHUB_WORKSPACE}/docker"
+      - name: Move /var/lib/containerd/
+        run: sudo mv /var/lib/containerd/ "${GITHUB_WORKSPACE}/docker"
 
       - name: Maximize build space
         uses: easimon/maximize-build-space@master
@@ -43,9 +43,9 @@ jobs:
           remove-android: "true"
           remove-haskell: "true"
           remove-codeql: "true"
-          build-mount-path: "/var/lib/docker/"
+          build-mount-path: "/var/lib/containerd/"
 
-      - name: Restore /var/lib/docker/
+      - name: Restore /var/lib/containerd/
         run: sudo sh -c "mv ${GITHUB_WORKSPACE}/docker/* /var/lib/docker"
 
       - name: Checkout source

--- a/.github/workflows/_build_in_container.yml
+++ b/.github/workflows/_build_in_container.yml
@@ -30,8 +30,11 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     name: Build wheel (${{ inputs.container-image }})
     steps:
-      - name: Move /var/lib/
-        run: sudo mv /var/lib/ "${GITHUB_WORKSPACE}/docker"
+      - name: Move /var/lib/containerd/
+        run: sudo mv /var/lib/containerd/ "${GITHUB_WORKSPACE}/docker/containerd"
+
+      - name: Move /var/lib/containerd/
+        run: sudo mv /var/lib/docker/ "${GITHUB_WORKSPACE}/docker/docker"
 
       - name: Maximize build space
         uses: easimon/maximize-build-space@master

--- a/.github/workflows/build_in_container_scheduled.yml
+++ b/.github/workflows/build_in_container_scheduled.yml
@@ -1,0 +1,48 @@
+name: Build wheels in a container (scheduled)
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * 1"
+
+jobs:
+  compute_matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      runners: ${{ steps.compute.outputs.RUNNERS }}
+      container-images: ${{ steps.compute.outputs.IMAGES }}
+      release-versions: ${{ steps.compute.outputs.RELEASES }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Check for NGC PyTorch images
+        run: bash ./.github/scripts/check_for_ngc_images.sh
+
+      - name: Check for upstream releases
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPSTREAM_REPO: state-spaces/mamba
+        run: bash ./.github/scripts/check_for_releases.sh
+
+      - name: Build matrix outputs
+        id: compute
+        run: |
+          echo "RUNNERS=$(jq -cn '["ubuntu-22.04","ubuntu-22.04-arm"]')" | tee -a "$GITHUB_OUTPUT"
+          echo "IMAGES=$(jq -cr . ngc_images.json)" | tee -a "$GITHUB_OUTPUT"
+          echo "RELEASES=$(jq -cr . releases.json)" | tee -a "$GITHUB_OUTPUT"
+
+  build-wheels:
+    needs: [compute_matrix]
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: ${{ fromJson(needs.compute_matrix.outputs.runners) }}
+        container-image: ${{ fromJson(needs.compute_matrix.outputs.container-images) }}
+        release-version: ${{ fromJson(needs.compute_matrix.outputs.release-versions) }}
+    uses: ./.github/workflows/_build_in_container.yml
+    with:
+      runs-on: ${{ matrix.runner }}
+      container-image: ${{ matrix.container-image }}
+      upload-to-release: false
+      release-version: ${{ matrix.release-version }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -40,12 +40,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Using ubuntu-20.04 instead of 22.04 for more compatibility (glibc). Ideally we'd use the
+        # Using ubuntu-22.04 instead of 24.04 for more compatibility (glibc). Ideally we'd use the
         # manylinux docker image, but I haven't figured out how to install CUDA on manylinux.
         os: [ubuntu-22.04]
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-        torch-version: ["2.1.2", "2.2.2", "2.3.1", "2.4.0", "2.5.1", "2.6.0.dev20241001"]
-        cuda-version: ["11.8.0", "12.3.2"]
+        torch-version: ["2.4.0", "2.5.1", "2.6.0", "2.7.1"]
+        cuda-version: ["11.8.0", "12.9.1"]
         # We need separate wheels that either uses C++11 ABI (-D_GLIBCXX_USE_CXX11_ABI) or not.
         # Pytorch wheels currently don't use it, but nvcr images have Pytorch compiled with C++11 ABI.
         # Without this we get import error (undefined symbol: _ZN3c105ErrorC2ENS_14SourceLocationESs)
@@ -53,19 +53,8 @@ jobs:
         cxx11_abi: ["FALSE", "TRUE"]
         exclude:
           # see https://github.com/pytorch/pytorch/blob/main/RELEASE.md#release-compatibility-matrix
-          # Pytorch < 2.2 does not support Python 3.12
-          - torch-version: "2.1.2"
-            python-version: "3.12"
-          # Pytorch < 2.5 does not support Python 3.13
-          - torch-version: "2.1.2"
-            python-version: "3.13"
-          - torch-version: "2.2.2"
-            python-version: "3.13"
-          - torch-version: "2.3.1"
-            python-version: "3.13"
           - torch-version: "2.4.0"
             python-version: "3.13"
-
     uses: ./.github/workflows/_build.yml
     with:
       runs-on: ${{ matrix.os }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -42,7 +42,7 @@ jobs:
       matrix:
         # Using ubuntu-22.04 instead of 24.04 for more compatibility (glibc). Ideally we'd use the
         # manylinux docker image, but I haven't figured out how to install CUDA on manylinux.
-        os: [ubuntu-22.04]
+        os: [ubuntu-22.04, ubuntu-22.04-arm]
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         torch-version: ["2.4.0", "2.5.1", "2.6.0", "2.7.1"]
         cuda-version: ["11.8.0", "12.9.1"]

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -97,6 +97,7 @@ jobs:
   publish_package:
     name: Publish package
     needs: [build_wheels]
+    if: always() && !cancelled()
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -85,7 +85,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-22.04, ubuntu-22.04-arm]
         container-image: ${{ fromJson(needs.check_for_ngc_images.outputs.images) }}
     uses: ./.github/workflows/_build_in_container.yml
     with:

--- a/mamba_ssm/__init__.py
+++ b/mamba_ssm/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.2.6.post2"
+__version__ = "2.2.6.post3"
 
 from mamba_ssm.ops.selective_scan_interface import selective_scan_fn, mamba_inner_fn
 from mamba_ssm.modules.mamba_simple import Mamba

--- a/mamba_ssm/__init__.py
+++ b/mamba_ssm/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.2.6.post3"
+__version__ = "2.3.0"
 
 from mamba_ssm.ops.selective_scan_interface import selective_scan_fn, mamba_inner_fn
 from mamba_ssm.modules.mamba_simple import Mamba

--- a/mamba_ssm/ops/triton/k_activations.py
+++ b/mamba_ssm/ops/triton/k_activations.py
@@ -5,16 +5,18 @@ import torch
 import triton
 import triton.language as tl
 
+from mamba_ssm.utils.determinism import autotune_configs
+
 
 @triton.autotune(
-    configs=[
+    configs=autotune_configs([
         triton.Config({'BLOCK_N': 32}),
         triton.Config({'BLOCK_N': 64}),
         triton.Config({'BLOCK_N': 128}),
         triton.Config({'BLOCK_N': 256}),
         triton.Config({'BLOCK_N': 512}),
         triton.Config({'BLOCK_N': 1024}),
-    ],
+    ]),
     key=['ncols'],
 )
 @triton.jit
@@ -61,14 +63,14 @@ def _swiglu_fwd(xy, out=None):
 
 
 @triton.autotune(
-    configs=[
+    configs=autotune_configs([
         triton.Config({'BLOCK_N': 32}),
         triton.Config({'BLOCK_N': 64}),
         triton.Config({'BLOCK_N': 128}),
         triton.Config({'BLOCK_N': 256}),
         triton.Config({'BLOCK_N': 512}),
         triton.Config({'BLOCK_N': 1024}),
-    ],
+    ]),
     key=['ncols'],
 )
 @triton.heuristics({"RECOMPUTE_OUTPUT": lambda args: args["OUT"] is not None})

--- a/mamba_ssm/ops/triton/layer_norm.py
+++ b/mamba_ssm/ops/triton/layer_norm.py
@@ -16,6 +16,8 @@ from mamba_ssm.utils.torch import custom_bwd, custom_fwd
 import triton
 import triton.language as tl
 
+from mamba_ssm.utils.determinism import autotune_configs
+
 
 def layer_norm_ref(
     x,
@@ -167,7 +169,7 @@ configs_autotune = [
 pruned_configs_autotune = config_prune(configs_autotune)
 
 @triton.autotune(
-    configs = pruned_configs_autotune,
+    configs=autotune_configs(pruned_configs_autotune),
     key=["N", "HAS_RESIDUAL", "STORE_RESIDUAL_OUT", "IS_RMS_NORM", "HAS_BIAS"],
 )
 # @triton.heuristics({"HAS_BIAS": lambda args: args["B"] is not None})
@@ -419,7 +421,7 @@ def _layer_norm_fwd(
 
 
 @triton.autotune(
-    configs=pruned_configs_autotune,
+    configs=autotune_configs(pruned_configs_autotune),
     key=["N", "HAS_DRESIDUAL", "STORE_DRESIDUAL", "IS_RMS_NORM", "HAS_BIAS", "HAS_DROPOUT"],
 )
 # @triton.heuristics({"HAS_BIAS": lambda args: args["B"] is not None})

--- a/mamba_ssm/ops/triton/ssd_bmm.py
+++ b/mamba_ssm/ops/triton/ssd_bmm.py
@@ -12,13 +12,15 @@ import triton.language as tl
 
 from einops import rearrange, repeat
 
+from mamba_ssm.utils.determinism import autotune_configs
+
 
 def init_to_zero(names):
     return lambda nargs: [nargs[name].zero_() for name in names if nargs[name] is not None]
 
 
 @triton.autotune(
-    configs=[
+    configs=autotune_configs([
         triton.Config({'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 256, 'BLOCK_SIZE_K': 64}, num_stages=3, num_warps=8),
         triton.Config({'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 256, 'BLOCK_SIZE_K': 32}, num_stages=4, num_warps=4),
         triton.Config({'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 32}, num_stages=4, num_warps=4),
@@ -28,7 +30,7 @@ def init_to_zero(names):
         triton.Config({'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 32, 'BLOCK_SIZE_K': 32}, num_stages=5, num_warps=2),
         triton.Config({'BLOCK_SIZE_M': 32, 'BLOCK_SIZE_N': 64, 'BLOCK_SIZE_K': 32}, num_stages=5, num_warps=2),
         triton.Config({'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 64, 'BLOCK_SIZE_K': 32}, num_stages=4, num_warps=2),
-    ],
+    ]),
     key=['chunk_size', 'K', 'IS_CAUSAL'],
 )
 @triton.jit
@@ -92,7 +94,7 @@ def _bmm_chunk_fwd_kernel(
 
 
 @triton.autotune(
-    configs=[
+    configs=autotune_configs([
         triton.Config({'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 256, 'BLOCK_SIZE_CS': 64}, num_stages=3, num_warps=8),
         triton.Config({'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 256, 'BLOCK_SIZE_CS': 32}, num_stages=4, num_warps=4),
         triton.Config({'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_CS': 32}, num_stages=4, num_warps=4),
@@ -102,7 +104,7 @@ def _bmm_chunk_fwd_kernel(
         triton.Config({'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 32, 'BLOCK_SIZE_CS': 32}, num_stages=5, num_warps=2),
         triton.Config({'BLOCK_SIZE_M': 32, 'BLOCK_SIZE_N': 64, 'BLOCK_SIZE_CS': 32}, num_stages=5, num_warps=2),
         triton.Config({'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 64, 'BLOCK_SIZE_CS': 32}, num_stages=4, num_warps=2),
-    ],
+    ]),
     key=['chunk_size', 'K'],
 )
 @triton.jit

--- a/mamba_ssm/ops/triton/ssd_chunk_scan.py
+++ b/mamba_ssm/ops/triton/ssd_chunk_scan.py
@@ -15,6 +15,12 @@ import triton.language as tl
 from einops import rearrange, repeat
 
 from mamba_ssm.ops.triton.ssd_bmm import _bmm_chunk_fwd, _bmm_chunk_bwd
+from mamba_ssm.utils.determinism import (
+    alloc_tile_workspace,
+    finalize_tile_workspace,
+    use_deterministic_mode,
+    autotune_configs,
+)
 
 TRITON_22 = version.parse(triton.__version__) >= version.parse('2.2.0')
 
@@ -24,7 +30,7 @@ def init_to_zero(names):
 
 
 @triton.autotune(
-    configs=[
+    configs=autotune_configs([
         triton.Config({'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 256, 'BLOCK_SIZE_K': 64}, num_stages=3, num_warps=8),
         triton.Config({'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 256, 'BLOCK_SIZE_K': 32}, num_stages=4, num_warps=4),
         triton.Config({'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 32}, num_stages=4, num_warps=4),
@@ -36,7 +42,7 @@ def init_to_zero(names):
         triton.Config({'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 32, 'BLOCK_SIZE_K': 32}, num_stages=5, num_warps=2),
         triton.Config({'BLOCK_SIZE_M': 32, 'BLOCK_SIZE_N': 64, 'BLOCK_SIZE_K': 32}, num_stages=5, num_warps=2),
         triton.Config({'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 64, 'BLOCK_SIZE_K': 32}, num_stages=4, num_warps=2),
-    ],
+    ]),
     key=['chunk_size', 'hdim', 'dstate', 'IS_CAUSAL'],
 )
 @triton.jit
@@ -175,14 +181,14 @@ def _chunk_scan_fwd_kernel(
 
 
 @triton.autotune(
-    configs=[
+    configs=autotune_configs([
         # triton.Config({'BLOCK_SIZE_N': 256}, num_stages=4, num_warps=4),
         # triton.Config({'BLOCK_SIZE_N': 128}, num_stages=4, num_warps=4),
         triton.Config({'BLOCK_SIZE_N': 64}, num_stages=4, num_warps=4),
         triton.Config({'BLOCK_SIZE_N': 32}, num_stages=4, num_warps=4),
         triton.Config({'BLOCK_SIZE_N': 64}, num_stages=4, num_warps=8),
         triton.Config({'BLOCK_SIZE_N': 32}, num_stages=4, num_warps=8),
-    ],
+    ]),
     key=['chunk_size', 'hdim', 'dstate'],
 )
 @triton.jit
@@ -331,12 +337,12 @@ def _chunk_scan_fwd_kernel_wip(
 
 
 @triton.autotune(
-    configs=[
+    configs=autotune_configs([
         triton.Config({'BLOCK_SIZE_M': 32}),
         triton.Config({'BLOCK_SIZE_M': 64}),
         triton.Config({'BLOCK_SIZE_M': 128}),
         triton.Config({'BLOCK_SIZE_M': 256}),
-    ],
+    ]),
     key=["chunk_size", "hdim"],
 )
 @triton.jit
@@ -426,7 +432,7 @@ def _chunk_scan_bwd_dz_kernel(
 
 
 @triton.autotune(
-    configs=[
+    configs=autotune_configs([
         triton.Config({'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 256, 'BLOCK_SIZE_K': 64}, num_stages=3, num_warps=8),
         triton.Config({'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 256, 'BLOCK_SIZE_K': 32}, num_stages=4, num_warps=4),
         triton.Config({'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 32}, num_stages=4, num_warps=4),
@@ -436,7 +442,7 @@ def _chunk_scan_bwd_dz_kernel(
         triton.Config({'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 32, 'BLOCK_SIZE_K': 32}, num_stages=5, num_warps=2),
         triton.Config({'BLOCK_SIZE_M': 32, 'BLOCK_SIZE_N': 64, 'BLOCK_SIZE_K': 32}, num_stages=5, num_warps=2),
         triton.Config({'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 64, 'BLOCK_SIZE_K': 32}, num_stages=4, num_warps=2),
-    ],
+    ]),
     key=['hdim', 'dstate', 'chunk_size'],
 )
 @triton.jit
@@ -508,7 +514,7 @@ def _chunk_scan_bwd_dstates_kernel(
 
 
 @triton.autotune(
-    configs=[
+    configs=autotune_configs([
         triton.Config({'BLOCK_SIZE_M': 32, 'BLOCK_SIZE_N': 128}, num_stages=3, num_warps=4, pre_hook=init_to_zero(["ddA_cumsum_ptr"])),
         triton.Config({'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 32}, num_stages=3, num_warps=4, pre_hook=init_to_zero(["ddA_cumsum_ptr"])),
         triton.Config({'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 128}, num_stages=3, num_warps=4, pre_hook=init_to_zero(["ddA_cumsum_ptr"])),
@@ -517,7 +523,7 @@ def _chunk_scan_bwd_dstates_kernel(
         triton.Config({'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 32}, num_stages=3, num_warps=4, pre_hook=init_to_zero(["ddA_cumsum_ptr"])),
         triton.Config({'BLOCK_SIZE_M': 32, 'BLOCK_SIZE_N': 64}, num_stages=3, num_warps=4, pre_hook=init_to_zero(["ddA_cumsum_ptr"])),
         triton.Config({'BLOCK_SIZE_M': 32, 'BLOCK_SIZE_N': 32}, num_stages=3, num_warps=4, pre_hook=init_to_zero(["ddA_cumsum_ptr"])),
-    ],
+    ]),
     key=['chunk_size', 'dstate', 'hdim'],
 )
 @triton.jit
@@ -535,10 +541,11 @@ def _chunk_scan_bwd_dc_kernel(
     stride_dA_cs_batch, stride_dA_cs_chunk, stride_dA_cs_head, stride_dA_cs_csize,
     stride_seq_idx_batch, stride_seq_idx_seqlen,
     stride_dc_batch, stride_dc_seqlen, stride_dc_split, stride_dc_group, stride_dc_dstate,
-    stride_ddA_cs_batch, stride_ddA_cs_chunk, stride_ddA_cs_head, stride_ddA_cs_csize,
+    stride_ddA_cs_batch, stride_ddA_cs_chunk, stride_ddA_cs_head, stride_ddA_cs_csize, stride_ddA_tile,
     # Meta-parameters
     HAS_DDA_CS: tl.constexpr,
     HAS_SEQ_IDX: tl.constexpr,
+    DETERMINISTIC_REDUCTION: tl.constexpr,
     BLOCK_SIZE_M: tl.constexpr, BLOCK_SIZE_N: tl.constexpr, BLOCK_SIZE_K: tl.constexpr,
 ):
     pid_bc = tl.program_id(axis=1)
@@ -556,7 +563,7 @@ def _chunk_scan_bwd_dc_kernel(
     dA_cumsum_ptr += pid_b * stride_dA_cs_batch + pid_c * stride_dA_cs_chunk + (pid_g * (nheads // ngroups) + pid_s * nheads_per_program) * stride_dA_cs_head
     if HAS_DDA_CS:
         C_ptr += pid_b * stride_C_batch + pid_c * chunk_size * stride_C_seqlen + pid_g * stride_C_head
-        ddA_cumsum_ptr += pid_b * stride_ddA_cs_batch + pid_c * stride_ddA_cs_chunk + (pid_g * (nheads // ngroups) + pid_s * nheads_per_program) * stride_ddA_cs_head
+        ddA_cumsum_ptr += pid_b * stride_ddA_cs_batch + pid_c * stride_ddA_cs_chunk + (pid_g * (nheads // ngroups) + pid_s * nheads_per_program) * stride_ddA_cs_head + pid_n * stride_ddA_tile
     if HAS_SEQ_IDX:
         seq_idx_ptr += pid_b * stride_seq_idx_batch + pid_c * chunk_size * stride_seq_idx_seqlen
 
@@ -591,7 +598,10 @@ def _chunk_scan_bwd_dc_kernel(
         dc *= scale[:, None]
         if HAS_DDA_CS:
             ddA_cs = tl.sum(dc * c, axis=1)
-            tl.atomic_add(ddA_cumsum_ptrs, ddA_cs, mask=offs_m < chunk_size)
+            if DETERMINISTIC_REDUCTION:
+                tl.store(ddA_cumsum_ptrs, ddA_cs, mask=offs_m < chunk_size)
+            else:
+                tl.atomic_add(ddA_cumsum_ptrs, ddA_cs, mask=offs_m < chunk_size)
         acc += dc
         dout_ptrs += stride_dout_head
         prev_states_ptrs += stride_prev_states_head
@@ -608,8 +618,13 @@ def _chunk_scan_bwd_dc_kernel(
     tl.store(dc_ptrs, acc, mask=(offs_m[:, None] < chunk_size_limit) & (offs_n[None, :] < dstate))
 
 
+_CHUNK_SCAN_BWD_DC_MIN_BLOCK_N = min(
+    cfg.kwargs['BLOCK_SIZE_N'] for cfg in _chunk_scan_bwd_dc_kernel.configs
+)
+
+
 @triton.autotune(
-    configs=[
+    configs=autotune_configs([
         triton.Config({'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 256, 'BLOCK_SIZE_K': 64}, num_stages=3, num_warps=8, pre_hook=init_to_zero(["ddt_ptr"])),
         triton.Config({'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 256, 'BLOCK_SIZE_K': 32}, num_stages=4, num_warps=4, pre_hook=init_to_zero(["ddt_ptr"])),
         triton.Config({'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 32}, num_stages=4, num_warps=4, pre_hook=init_to_zero(["ddt_ptr"])),
@@ -619,7 +634,7 @@ def _chunk_scan_bwd_dc_kernel(
         triton.Config({'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 32, 'BLOCK_SIZE_K': 32}, num_stages=5, num_warps=4, pre_hook=init_to_zero(["ddt_ptr"])),
         triton.Config({'BLOCK_SIZE_M': 32, 'BLOCK_SIZE_N': 64, 'BLOCK_SIZE_K': 32}, num_stages=5, num_warps=4, pre_hook=init_to_zero(["ddt_ptr"])),
         triton.Config({'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 64, 'BLOCK_SIZE_K': 32}, num_stages=4, num_warps=4, pre_hook=init_to_zero(["ddt_ptr"])),
-    ],
+    ]),
     key=['chunk_size', 'hdim'],
 )
 @triton.jit
@@ -638,11 +653,12 @@ def _chunk_scan_bwd_dx_kernel(
     stride_dA_cs_batch, stride_dA_cs_chunk, stride_dA_cs_head, stride_dA_cs_csize,
     stride_D_head,
     stride_dx_batch, stride_dx_seqlen, stride_dx_head, stride_dx_hdim,
-    stride_ddt_batch, stride_ddt_chunk, stride_ddt_head, stride_ddt_csize,
+    stride_ddt_batch, stride_ddt_chunk, stride_ddt_head, stride_ddt_csize, stride_ddt_tile,
     # stride_dD_batch, stride_dD_chunk, stride_dD_head, stride_dD_hdim, stride_dD_csize,
     # Meta-parameters
     HAS_D: tl.constexpr,
     D_HAS_HDIM: tl.constexpr,
+    DETERMINISTIC_REDUCTION: tl.constexpr,
     BLOCK_SIZE_M: tl.constexpr, BLOCK_SIZE_N: tl.constexpr, BLOCK_SIZE_K: tl.constexpr,
 ):
     pid_bc = tl.program_id(axis=1)
@@ -656,7 +672,7 @@ def _chunk_scan_bwd_dx_kernel(
     cb_ptr += pid_b * stride_cb_batch + pid_c * stride_cb_chunk + (pid_h // nheads_ngroups_ratio) * stride_cb_head
     dout_ptr += pid_b * stride_dout_batch + pid_c * chunk_size * stride_dout_seqlen + pid_h * stride_dout_head
     dt_ptr += pid_b * stride_dt_batch + pid_c * stride_dt_chunk + pid_h * stride_dt_head
-    ddt_ptr += pid_b * stride_ddt_batch + pid_c * stride_ddt_chunk + pid_h * stride_ddt_head
+    ddt_ptr += pid_b * stride_ddt_batch + pid_c * stride_ddt_chunk + pid_h * stride_ddt_head + pid_n * stride_ddt_tile
     dA_cumsum_ptr += pid_b * stride_dA_cs_batch + pid_c * stride_dA_cs_chunk + pid_h * stride_dA_cs_head
     # if HAS_D:
     #     dD_ptr += pid_b * stride_dD_batch + pid_c * stride_dD_chunk + pid_h * stride_dD_head + pid_m * stride_dD_csize
@@ -715,7 +731,10 @@ def _chunk_scan_bwd_dx_kernel(
     x = tl.load(x_ptrs, mask=(offs_m[:, None] < chunk_size_limit) & (offs_n[None, :] < hdim), other=0.0).to(tl.float32)
     ddt = tl.sum(acc * x, axis=1)
     ddt_ptrs = ddt_ptr + offs_m * stride_ddt_csize
-    tl.atomic_add(ddt_ptrs, ddt, mask=offs_m < chunk_size)
+    if DETERMINISTIC_REDUCTION:
+        tl.store(ddt_ptrs, ddt, mask=offs_m < chunk_size)
+    else:
+        tl.atomic_add(ddt_ptrs, ddt, mask=offs_m < chunk_size)
 
     # if HAS_D:
     #     dout_new_ptrs = dout_ptr + (offs_m[:, None] * stride_dout_csize + offs_n[None, :] * stride_dout_hdim)
@@ -724,9 +743,14 @@ def _chunk_scan_bwd_dx_kernel(
     #     tl.store(dD_ptr + offs_n * stride_dD_hdim, dD, mask=offs_n < N)
 
 
+_CHUNK_SCAN_BWD_DX_MIN_BLOCK_N = min(
+    cfg.kwargs['BLOCK_SIZE_N'] for cfg in _chunk_scan_bwd_dx_kernel.configs
+)
+
+
 # Disabling HAS_DDA_CS for now since it's much slower
 @triton.autotune(
-    configs=[
+    configs=autotune_configs([
         triton.Config({'BLOCK_SIZE_M': 32, 'BLOCK_SIZE_N': 128}, num_stages=3, num_warps=4),
         triton.Config({'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 32}, num_stages=3, num_warps=4),
         triton.Config({'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 64}, num_stages=3, num_warps=4),
@@ -741,7 +765,7 @@ def _chunk_scan_bwd_dx_kernel(
         # triton.Config({'BLOCK_SIZE_M': 32}, num_stages=4, num_warps=8),
         # triton.Config({'BLOCK_SIZE_M': 64}, num_stages=4, num_warps=8),
         # triton.Config({'BLOCK_SIZE_M': 128}, num_stages=4, num_warps=8),
-    ],
+    ]),
     key=['chunk_size', 'hdim'],
 )
 # @triton.heuristics({"BLOCK_SIZE_N": lambda args: max(triton.next_power_of_2(args["chunk_size"]), 16)})
@@ -853,12 +877,12 @@ def _chunk_scan_bwd_dcb_kernel(
 
 # Not numerically stable and should not be used. Leaving here for reference.
 @triton.autotune(
-    configs=[
+    configs=autotune_configs([
         triton.Config({'BLOCK_SIZE_M': 32}),
         triton.Config({'BLOCK_SIZE_M': 64}),
         triton.Config({'BLOCK_SIZE_M': 128}),
         triton.Config({'BLOCK_SIZE_M': 256}),
-    ],
+    ]),
     key=["chunk_size", "hdim"],
 )
 @triton.jit
@@ -931,7 +955,7 @@ def _chunk_scan_bwd_ddAcs_unstable_kernel(
 
 
 @triton.autotune(
-    configs=[
+    configs=autotune_configs([
         # triton.Config({'BLOCK_SIZE_M': 16, 'BLOCK_SIZE_K': 32}, num_stages=3, num_warps=4),
         # triton.Config({'BLOCK_SIZE_M': 32, 'BLOCK_SIZE_K': 32}, num_stages=3, num_warps=4),
         # triton.Config({'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_K': 32}, num_stages=3, num_warps=4),
@@ -948,7 +972,7 @@ def _chunk_scan_bwd_ddAcs_unstable_kernel(
         triton.Config({'BLOCK_SIZE_M': 32}, num_stages=4, num_warps=8),
         triton.Config({'BLOCK_SIZE_M': 64}, num_stages=4, num_warps=8),
         triton.Config({'BLOCK_SIZE_M': 128}, num_stages=4, num_warps=8),
-    ],
+    ]),
     key=['chunk_size', 'hdim'],
 )
 @triton.jit
@@ -1057,7 +1081,7 @@ def _chunk_scan_bwd_ddAcs_stable_kernel_old(
 
 
 @triton.autotune(
-    configs=[
+    configs=autotune_configs([
         triton.Config({'BLOCK_SIZE_M': 32, 'BLOCK_SIZE_N': 32}, num_stages=3, num_warps=4),
         # triton.Config({'BLOCK_SIZE_M': 32, 'BLOCK_SIZE_N': 64}, num_stages=3, num_warps=4),
         # triton.Config({'BLOCK_SIZE_M': 32, 'BLOCK_SIZE_N': 128}, num_stages=3, num_warps=4),
@@ -1067,7 +1091,7 @@ def _chunk_scan_bwd_ddAcs_stable_kernel_old(
         triton.Config({'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 32}, num_stages=3, num_warps=4),
         triton.Config({'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 64}, num_stages=3, num_warps=4),
         triton.Config({'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 128}, num_stages=3, num_warps=4),
-    ],
+    ]),
     key=['chunk_size', 'hdim'],
 )
 @triton.jit
@@ -1160,14 +1184,14 @@ def _chunk_scan_bwd_ddAcs_stable_kernel(
 
 
 @triton.autotune(
-    configs=[
+    configs=autotune_configs([
         triton.Config({'BLOCK_SIZE_M': 32, 'BLOCK_SIZE_N': 128}, num_stages=3, num_warps=4, pre_hook=init_to_zero(["ddA_cumsum_ptr"])),
         triton.Config({'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 32}, num_stages=3, num_warps=4, pre_hook=init_to_zero(["ddA_cumsum_ptr"])),
         triton.Config({'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 64}, num_stages=3, num_warps=4, pre_hook=init_to_zero(["ddA_cumsum_ptr"])),
         triton.Config({'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 32}, num_stages=3, num_warps=4, pre_hook=init_to_zero(["ddA_cumsum_ptr"])),
         triton.Config({'BLOCK_SIZE_M': 32, 'BLOCK_SIZE_N': 64}, num_stages=3, num_warps=4, pre_hook=init_to_zero(["ddA_cumsum_ptr"])),
         triton.Config({'BLOCK_SIZE_M': 32, 'BLOCK_SIZE_N': 32}, num_stages=3, num_warps=4, pre_hook=init_to_zero(["ddA_cumsum_ptr"])),
-    ],
+    ]),
     key=['chunk_size', 'dstate', 'hdim'],
 )
 @triton.jit
@@ -1433,15 +1457,30 @@ def _chunk_scan_bwd_dC(prev_states, dA_cumsum, dout, seq_idx=None, C=None, ngrou
     assert dout.shape == (batch, seqlen, nheads, headdim)
     if seq_idx is not None:
         assert seq_idx.shape == (batch, seqlen)
+    deterministic = use_deterministic_mode()
     if C is not None:
         assert C.shape == (batch, seqlen, ngroups, dstate)
         C_strides = (C.stride(0), C.stride(1), C.stride(2), C.stride(3))
-        ddA_cumsum_prev = torch.empty(batch, nheads, nchunks, chunk_size, device=dout.device, dtype=torch.float32)
-        ddA_cumsum_prev_strides = (ddA_cumsum_prev.stride(0), ddA_cumsum_prev.stride(2), ddA_cumsum_prev.stride(1), ddA_cumsum_prev.stride(3))
+        tile_count = math.ceil(dstate / _CHUNK_SCAN_BWD_DC_MIN_BLOCK_N)
+        ddA_cumsum_prev, stride_ddA_tile = alloc_tile_workspace(
+            (batch, nheads, nchunks, chunk_size),
+            tile_count,
+            torch.float32,
+            dout.device,
+            deterministic,
+            zero_init=True,
+        )
+        ddA_cumsum_prev_strides = (
+            ddA_cumsum_prev.stride(0),
+            ddA_cumsum_prev.stride(2),
+            ddA_cumsum_prev.stride(1),
+            ddA_cumsum_prev.stride(3),
+        )
     else:
         C_strides = (0, 0, 0, 0)
         ddA_cumsum_prev = None
         ddA_cumsum_prev_strides = (0, 0, 0, 0)
+        stride_ddA_tile = 0
     nheads_ngroups_ratio = nheads // ngroups
     sm_count = torch.cuda.get_device_properties(dout.device).multi_processor_count
     nheads_per_program = max(min(math.ceil(batch * nchunks * nheads / sm_count), nheads_ngroups_ratio), 1)
@@ -1460,12 +1499,15 @@ def _chunk_scan_bwd_dC(prev_states, dA_cumsum, dout, seq_idx=None, C=None, ngrou
             dA_cumsum.stride(0), dA_cumsum.stride(2), dA_cumsum.stride(1), dA_cumsum.stride(3),
             *((seq_idx.stride(0), seq_idx.stride(1)) if seq_idx is not None else (0, 0)),
             dC.stride(0), dC.stride(1), dC.stride(2), dC.stride(3), dC.stride(4),
-            *ddA_cumsum_prev_strides,
+            *ddA_cumsum_prev_strides, stride_ddA_tile,
             HAS_DDA_CS=ddA_cumsum_prev is not None,
             HAS_SEQ_IDX=seq_idx is not None,
+            DETERMINISTIC_REDUCTION=deterministic,
             BLOCK_SIZE_K=max(triton.next_power_of_2(headdim), 16),
         )
     dC = dC.sum(2)
+    if ddA_cumsum_prev is not None:
+        ddA_cumsum_prev = finalize_tile_workspace(ddA_cumsum_prev, deterministic)
     return dC if C is None else (dC, ddA_cumsum_prev)
 
 
@@ -1535,7 +1577,16 @@ def _chunk_scan_bwd_dx(cb, x, dt, dA_cumsum, dout, D=None):
     # else:
     #     dD = None
     dx = torch.empty_like(x)
-    ddt = torch.empty(batch, nheads, nchunks, chunk_size, device=dout.device, dtype=torch.float32)
+    deterministic = use_deterministic_mode()
+    tile_count = math.ceil(headdim / _CHUNK_SCAN_BWD_DX_MIN_BLOCK_N)
+    ddt, stride_ddt_tile = alloc_tile_workspace(
+        (batch, nheads, nchunks, chunk_size),
+        tile_count,
+        torch.float32,
+        dout.device,
+        deterministic,
+        zero_init=True,
+    )
     grid_dx = lambda META: (triton.cdiv(chunk_size, META['BLOCK_SIZE_M']) * triton.cdiv(headdim, META['BLOCK_SIZE_N']),
                         batch * nchunks, nheads)
     with torch.cuda.device(x.device.index):
@@ -1550,16 +1601,18 @@ def _chunk_scan_bwd_dx(cb, x, dt, dA_cumsum, dout, D=None):
             dA_cumsum.stride(0), dA_cumsum.stride(2), dA_cumsum.stride(1), dA_cumsum.stride(3),
             D.stride(0) if D is not None else 0,
             dx.stride(0), dx.stride(1), dx.stride(2), dx.stride(3),
-            ddt.stride(0), ddt.stride(2), ddt.stride(1), ddt.stride(3),
+            ddt.stride(0), ddt.stride(2), ddt.stride(1), ddt.stride(3), stride_ddt_tile,
             # dD.stride(1) if dD is not None else 0, dD.stride(2) if dD is not None else 0, dD.stride(3) if dD is not None else 0, dD.stride(4) if dD is not None else 0, dD.stride(0) if dD is not None else 0,
             D is not None,
             D.dim() == 2 if D is not None else True,
+            DETERMINISTIC_REDUCTION=deterministic,
         )
     # if D is not None:
     #     BLOCK_SIZE_actual = _chunk_scan_bwd_dx_kernel.best_config.kwargs["BLOCK_SIZE_M"]
     #     n_valid_blocks = (chunk_size + BLOCK_SIZE_actual - 1) // BLOCK_SIZE_actual
     #     dD = dD[:n_valid_blocks].sum(dim=(0, 1, 2)).to(dtype=D.dtype)
-    return dx, ddt.to(dtype=dt.dtype)
+    ddt = finalize_tile_workspace(ddt, deterministic)
+    return dx, ddt
 
 
 def _chunk_scan_bwd_ddAcs_unstable(x, dt, out, dout, ddt, D=None, subtract_ddtdt=True):

--- a/mamba_ssm/ops/triton/ssd_chunk_state.py
+++ b/mamba_ssm/ops/triton/ssd_chunk_state.py
@@ -13,13 +13,19 @@ import triton.language as tl
 from einops import rearrange, repeat
 
 from mamba_ssm.ops.triton.softplus import softplus
+from mamba_ssm.utils.determinism import (
+    alloc_tile_workspace,
+    finalize_tile_workspace,
+    use_deterministic_mode,
+    autotune_configs,
+)
 
 
 def init_to_zero(names):
     return lambda nargs: [nargs[name].zero_() for name in names if nargs[name] is not None]
 
 @triton.autotune(
-    configs=[
+    configs=autotune_configs([
         triton.Config({'BLOCK_SIZE_H': 1}),
         triton.Config({'BLOCK_SIZE_H': 2}),
         triton.Config({'BLOCK_SIZE_H': 4}),
@@ -27,7 +33,7 @@ def init_to_zero(names):
         triton.Config({'BLOCK_SIZE_H': 16}),
         triton.Config({'BLOCK_SIZE_H': 32}),
         triton.Config({'BLOCK_SIZE_H': 64}),
-    ],
+    ]),
     key=['chunk_size', 'nheads'],
 )
 @triton.jit
@@ -81,7 +87,7 @@ def _chunk_cumsum_fwd_kernel(
 
 
 @triton.autotune(
-    configs=[
+    configs=autotune_configs([
         triton.Config({'BLOCK_SIZE_H': 1}, pre_hook=init_to_zero(["dA_ptr", "ddt_bias_ptr"])),
         triton.Config({'BLOCK_SIZE_H': 2}, pre_hook=init_to_zero(["dA_ptr", "ddt_bias_ptr"])),
         triton.Config({'BLOCK_SIZE_H': 4}, pre_hook=init_to_zero(["dA_ptr", "ddt_bias_ptr"])),
@@ -89,7 +95,7 @@ def _chunk_cumsum_fwd_kernel(
         triton.Config({'BLOCK_SIZE_H': 16}, pre_hook=init_to_zero(["dA_ptr", "ddt_bias_ptr"])),
         triton.Config({'BLOCK_SIZE_H': 32}, pre_hook=init_to_zero(["dA_ptr", "ddt_bias_ptr"])),
         triton.Config({'BLOCK_SIZE_H': 64}, pre_hook=init_to_zero(["dA_ptr", "ddt_bias_ptr"])),
-    ],
+    ]),
     key=['chunk_size', 'nheads'],
 )
 @triton.jit
@@ -107,12 +113,13 @@ def _chunk_cumsum_bwd_kernel(
     stride_A_head,
     stride_dt_bias_head,
     stride_ddt_batch, stride_ddt_seqlen, stride_ddt_head,
-    stride_dA_head,
-    stride_ddt_bias_head,
+    stride_dA_batch, stride_dA_chunk, stride_dA_head,
+    stride_ddt_bias_batch, stride_ddt_bias_chunk, stride_ddt_bias_head,
     # Meta-parameters
     DT_SOFTPLUS: tl.constexpr,
     HAS_DT_BIAS: tl.constexpr,
     BLOCK_SIZE_H: tl.constexpr, BLOCK_SIZE_CHUNK: tl.constexpr,
+    DETERMINISTIC_REDUCTION: tl.constexpr,
 ):
     pid_b = tl.program_id(axis=0)
     pid_c = tl.program_id(axis=1)
@@ -153,14 +160,22 @@ def _chunk_cumsum_bwd_kernel(
         ddt = tl.where(dt_presoftplus <= 20.0, ddt * tl.sigmoid(dt_presoftplus), ddt)
     tl.store(ddt_ptrs, ddt, mask=(offs_h[:, None] < nheads) & (offs_c[None, :] < chunk_size_limit))
     dA = tl.sum(ddA * dt, axis=1)
-    tl.atomic_add(dA_ptr + offs_h * stride_dA_head, dA, mask=offs_h < nheads)
+    dA_ptr += pid_b * stride_dA_batch + pid_c * stride_dA_chunk
+    if DETERMINISTIC_REDUCTION:
+        tl.store(dA_ptr + offs_h * stride_dA_head, dA, mask=offs_h < nheads)
+    else:
+        tl.atomic_add(dA_ptr + offs_h * stride_dA_head, dA, mask=offs_h < nheads)
     if HAS_DT_BIAS:
         ddt_bias = tl.sum(ddt, axis=1)
-        tl.atomic_add(ddt_bias_ptr + offs_h * stride_ddt_bias_head, ddt_bias, mask=offs_h < nheads)
+        ddt_bias_ptr += pid_b * stride_ddt_bias_batch + pid_c * stride_ddt_bias_chunk
+        if DETERMINISTIC_REDUCTION:
+            tl.store(ddt_bias_ptr + offs_h * stride_ddt_bias_head, ddt_bias, mask=offs_h < nheads)
+        else:
+            tl.atomic_add(ddt_bias_ptr + offs_h * stride_ddt_bias_head, ddt_bias, mask=offs_h < nheads)
 
 
 @triton.autotune(
-    configs=[
+    configs=autotune_configs([
         triton.Config({'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 256, 'BLOCK_SIZE_K': 64}, num_stages=3, num_warps=8),
         triton.Config({'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 256, 'BLOCK_SIZE_K': 32}, num_stages=4, num_warps=4),
         triton.Config({'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 32}, num_stages=4, num_warps=4),
@@ -170,7 +185,7 @@ def _chunk_cumsum_bwd_kernel(
         triton.Config({'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 32, 'BLOCK_SIZE_K': 32}, num_stages=5, num_warps=2),
         triton.Config({'BLOCK_SIZE_M': 32, 'BLOCK_SIZE_N': 64, 'BLOCK_SIZE_K': 32}, num_stages=5, num_warps=2),
         triton.Config({'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 64, 'BLOCK_SIZE_K': 32}, num_stages=4, num_warps=2),
-    ],
+    ]),
     key=['hdim', 'dstate', 'chunk_size'],
 )
 @triton.jit
@@ -254,7 +269,7 @@ def _chunk_state_fwd_kernel(
 
 
 @triton.autotune(
-    configs=[
+    configs=autotune_configs([
         triton.Config({'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 256, 'BLOCK_SIZE_K': 64}, num_stages=3, num_warps=8, pre_hook=init_to_zero(["ddt_ptr", "ddA_cumsum_ptr"])),
         triton.Config({'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 256, 'BLOCK_SIZE_K': 32}, num_stages=4, num_warps=4, pre_hook=init_to_zero(["ddt_ptr", "ddA_cumsum_ptr"])),
         triton.Config({'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 32}, num_stages=4, num_warps=4, pre_hook=init_to_zero(["ddt_ptr", "ddA_cumsum_ptr"])),
@@ -264,7 +279,7 @@ def _chunk_state_fwd_kernel(
         triton.Config({'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 32, 'BLOCK_SIZE_K': 32}, num_stages=5, num_warps=4, pre_hook=init_to_zero(["ddt_ptr", "ddA_cumsum_ptr"])),
         triton.Config({'BLOCK_SIZE_M': 32, 'BLOCK_SIZE_N': 64, 'BLOCK_SIZE_K': 32}, num_stages=5, num_warps=4, pre_hook=init_to_zero(["ddt_ptr", "ddA_cumsum_ptr"])),
         triton.Config({'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 64, 'BLOCK_SIZE_K': 32}, num_stages=4, num_warps=4, pre_hook=init_to_zero(["ddt_ptr", "ddA_cumsum_ptr"])),
-    ],
+    ]),
     key=['chunk_size', 'hdim', 'dstate'],
 )
 @triton.jit
@@ -282,9 +297,10 @@ def _chunk_state_bwd_dx_kernel(
     stride_dt_batch, stride_dt_chunk, stride_dt_head, stride_dt_csize,
     stride_dA_cs_batch, stride_dA_cs_chunk, stride_dA_cs_head, stride_dA_cs_csize,
     stride_dx_batch, stride_dx_seqlen, stride_dx_head, stride_dx_hdim,
-    stride_ddt_batch, stride_ddt_chunk, stride_ddt_head, stride_ddt_csize,
-    stride_ddA_cs_batch, stride_ddA_cs_chunk, stride_ddA_cs_head, stride_ddA_cs_csize,
+    stride_ddt_batch, stride_ddt_chunk, stride_ddt_head, stride_ddt_csize, stride_ddt_tile,
+    stride_ddA_cs_batch, stride_ddA_cs_chunk, stride_ddA_cs_head, stride_ddA_cs_csize, stride_ddA_tile,
     # Meta-parameters
+    DETERMINISTIC_REDUCTION: tl.constexpr,
     BLOCK_SIZE_M: tl.constexpr, BLOCK_SIZE_N: tl.constexpr, BLOCK_SIZE_K: tl.constexpr,
     BLOCK_SIZE_DSTATE: tl.constexpr,
 ):
@@ -299,8 +315,8 @@ def _chunk_state_bwd_dx_kernel(
     b_ptr += pid_b * stride_b_batch + pid_c * chunk_size * stride_b_seqlen + (pid_h // nheads_ngroups_ratio) * stride_b_head
     dstates_ptr += pid_b * stride_dstates_batch + pid_c * stride_dstates_chunk + pid_h * stride_states_head
     dt_ptr += pid_b * stride_dt_batch + pid_c * stride_dt_chunk + pid_h * stride_dt_head
-    ddt_ptr += pid_b * stride_ddt_batch + pid_c * stride_ddt_chunk + pid_h * stride_ddt_head
-    ddA_cumsum_ptr += pid_b * stride_ddA_cs_batch + pid_c * stride_ddA_cs_chunk + pid_h * stride_ddA_cs_head
+    ddt_ptr += pid_b * stride_ddt_batch + pid_c * stride_ddt_chunk + pid_h * stride_ddt_head + pid_n * stride_ddt_tile
+    ddA_cumsum_ptr += pid_b * stride_ddA_cs_batch + pid_c * stride_ddA_cs_chunk + pid_h * stride_ddA_cs_head + pid_n * stride_ddA_tile
     dA_cumsum_ptr += pid_b * stride_dA_cs_batch + pid_c * stride_dA_cs_chunk + pid_h * stride_dA_cs_head
 
     offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
@@ -341,12 +357,18 @@ def _chunk_state_bwd_dx_kernel(
     x = tl.load(x_ptrs, mask=(offs_m[:, None] < chunk_size_limit) & (offs_n[None, :] < hdim), other=0.0).to(tl.float32)
     ddt = tl.sum(acc * x, axis=1)
     ddt_ptrs = ddt_ptr + offs_m * stride_ddt_csize
-    tl.atomic_add(ddt_ptrs, ddt, mask=offs_m < chunk_size)
+    if DETERMINISTIC_REDUCTION:
+        tl.store(ddt_ptrs, ddt, mask=offs_m < chunk_size)
+    else:
+        tl.atomic_add(ddt_ptrs, ddt, mask=offs_m < chunk_size)
     ddA_cs = -(ddt * dt_m)
     ddA_cs_last = -tl.sum(ddA_cs)
     ddA_cumsum_ptrs = ddA_cumsum_ptr + offs_m * stride_ddA_cs_csize
-    tl.atomic_add(ddA_cumsum_ptrs, ddA_cs, mask=offs_m < chunk_size)
-    tl.atomic_add(ddA_cumsum_ptr + (chunk_size - 1) * stride_ddA_cs_csize, ddA_cs_last)
+    if DETERMINISTIC_REDUCTION:
+        tl.store(ddA_cumsum_ptrs, ddA_cs, mask=offs_m < chunk_size)
+    else:
+        tl.atomic_add(ddA_cumsum_ptrs, ddA_cs, mask=offs_m < chunk_size)
+        tl.atomic_add(ddA_cumsum_ptr + (chunk_size - 1) * stride_ddA_cs_csize, ddA_cs_last)
 
     dx = (acc * dt_m[:, None]).to(dx_ptr.dtype.element_ty)
     dx_ptr += pid_b * stride_dx_batch + pid_c * chunk_size * stride_dx_seqlen + pid_h * stride_dx_head
@@ -354,8 +376,13 @@ def _chunk_state_bwd_dx_kernel(
     tl.store(dx_ptrs, dx, mask=(offs_m[:, None] < chunk_size_limit) & (offs_n[None, :] < hdim))
 
 
+_CHUNK_STATE_BWD_DX_MIN_BLOCK_N = min(
+    cfg.kwargs['BLOCK_SIZE_N'] for cfg in _chunk_state_bwd_dx_kernel.configs
+)
+
+
 @triton.autotune(
-    configs=[
+    configs=autotune_configs([
         triton.Config({'BLOCK_SIZE_M': 32, 'BLOCK_SIZE_N': 128}, num_stages=3, num_warps=4, pre_hook=init_to_zero(["ddA_cumsum_ptr"])),
         triton.Config({'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 32}, num_stages=3, num_warps=4, pre_hook=init_to_zero(["ddA_cumsum_ptr"])),
         triton.Config({'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 128}, num_stages=3, num_warps=4, pre_hook=init_to_zero(["ddA_cumsum_ptr"])),
@@ -364,7 +391,7 @@ def _chunk_state_bwd_dx_kernel(
         triton.Config({'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 32}, num_stages=3, num_warps=4, pre_hook=init_to_zero(["ddA_cumsum_ptr"])),
         triton.Config({'BLOCK_SIZE_M': 32, 'BLOCK_SIZE_N': 64}, num_stages=3, num_warps=4, pre_hook=init_to_zero(["ddA_cumsum_ptr"])),
         triton.Config({'BLOCK_SIZE_M': 32, 'BLOCK_SIZE_N': 32}, num_stages=3, num_warps=4, pre_hook=init_to_zero(["ddA_cumsum_ptr"])),
-    ],
+    ]),
     key=['chunk_size', 'dstate', 'hdim'],
 )
 @triton.jit
@@ -383,10 +410,11 @@ def _chunk_state_bwd_db_kernel(
     stride_dA_cs_batch, stride_dA_cs_chunk, stride_dA_cs_head, stride_dA_cs_csize,
     stride_seq_idx_batch, stride_seq_idx_seqlen,
     stride_db_batch, stride_db_seqlen, stride_db_split, stride_db_group, stride_db_dstate,
-    stride_ddA_cs_batch, stride_ddA_cs_chunk, stride_ddA_cs_head, stride_ddA_cs_csize,
+    stride_ddA_cs_batch, stride_ddA_cs_chunk, stride_ddA_cs_head, stride_ddA_cs_csize, stride_ddA_tile,
     # Meta-parameters
     HAS_DDA_CS: tl.constexpr,
     HAS_SEQ_IDX: tl.constexpr,
+    DETERMINISTIC_REDUCTION: tl.constexpr,
     BLOCK_SIZE_M: tl.constexpr, BLOCK_SIZE_N: tl.constexpr, BLOCK_SIZE_K: tl.constexpr,
 ):
     pid_bc = tl.program_id(axis=1)
@@ -405,7 +433,7 @@ def _chunk_state_bwd_db_kernel(
     dA_cumsum_ptr += pid_b * stride_dA_cs_batch + pid_c * stride_dA_cs_chunk + (pid_g * (nheads // ngroups) + pid_s * nheads_per_program) * stride_dA_cs_head
     if HAS_DDA_CS:
         b_ptr += pid_b * stride_b_batch + pid_c * chunk_size * stride_b_seqlen + pid_g * stride_b_head
-        ddA_cumsum_ptr += pid_b * stride_ddA_cs_batch + pid_c * stride_ddA_cs_chunk + (pid_g * (nheads // ngroups) + pid_s * nheads_per_program) * stride_ddA_cs_head
+        ddA_cumsum_ptr += pid_b * stride_ddA_cs_batch + pid_c * stride_ddA_cs_chunk + (pid_g * (nheads // ngroups) + pid_s * nheads_per_program) * stride_ddA_cs_head + pid_n * stride_ddA_tile
     if HAS_SEQ_IDX:
         seq_idx_ptr += pid_b * stride_seq_idx_batch + pid_c * chunk_size * stride_seq_idx_seqlen
 
@@ -446,7 +474,10 @@ def _chunk_state_bwd_db_kernel(
         if HAS_DDA_CS:
             # This is the gradient wrt (dA_cs_last - dA_cs_m), i.e. the exclusive reverse cumsum
             ddA_cs = tl.sum(db * b, axis=1)
-            tl.atomic_add(ddA_cumsum_ptrs + stride_ddA_cs_csize, ddA_cs, mask=offs_m < chunk_size - 1)
+            if DETERMINISTIC_REDUCTION:
+                tl.store(ddA_cumsum_ptrs + stride_ddA_cs_csize, ddA_cs, mask=offs_m < chunk_size - 1)
+            else:
+                tl.atomic_add(ddA_cumsum_ptrs + stride_ddA_cs_csize, ddA_cs, mask=offs_m < chunk_size - 1)
         acc += db
         x_ptrs += stride_x_head
         dstates_ptrs += stride_states_head
@@ -466,8 +497,13 @@ def _chunk_state_bwd_db_kernel(
     tl.store(db_ptrs, acc, mask=(offs_m[:, None] < chunk_size_limit) & (offs_n[None, :] < dstate))
 
 
+_CHUNK_STATE_BWD_DB_MIN_BLOCK_N = min(
+    cfg.kwargs['BLOCK_SIZE_N'] for cfg in _chunk_state_bwd_db_kernel.configs
+)
+
+
 @triton.autotune(
-    configs=[
+    configs=autotune_configs([
         # triton.Config({'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 256, 'BLOCK_SIZE_K': 64}, num_stages=3, num_warps=8, pre_hook=init_to_zero(["ddA_cumsum_ptr"])),
         # triton.Config({'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 256, 'BLOCK_SIZE_K': 32}, num_stages=4, num_warps=4, pre_hook=init_to_zero(["ddA_cumsum_ptr"])),
         # triton.Config({'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 32}, num_stages=4, num_warps=4, pre_hook=init_to_zero(["ddA_cumsum_ptr"])),
@@ -485,7 +521,7 @@ def _chunk_state_bwd_db_kernel(
         triton.Config({'BLOCK_SIZE_N': 32, 'BLOCK_SIZE_K': 32}, num_stages=4, num_warps=8, pre_hook=init_to_zero(["ddA_cumsum_ptr"])),
         triton.Config({'BLOCK_SIZE_N': 64, 'BLOCK_SIZE_K': 32}, num_stages=4, num_warps=8, pre_hook=init_to_zero(["ddA_cumsum_ptr"])),
         triton.Config({'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 32}, num_stages=4, num_warps=8, pre_hook=init_to_zero(["ddA_cumsum_ptr"])),
-    ],
+    ]),
     key=['chunk_size', 'hdim', 'dstate'],
 )
 @triton.jit
@@ -503,9 +539,10 @@ def _chunk_state_bwd_ddAcs_stable_kernel(
     stride_dt_batch, stride_dt_chunk, stride_dt_head, stride_dt_csize,
     stride_dA_cs_batch, stride_dA_cs_chunk, stride_dA_cs_head, stride_dA_cs_csize,
     stride_seq_idx_batch, stride_seq_idx_seqlen,
-    stride_ddA_cs_batch, stride_ddA_cs_chunk, stride_ddA_cs_head, stride_ddA_cs_csize,
+    stride_ddA_cs_batch, stride_ddA_cs_chunk, stride_ddA_cs_head, stride_ddA_cs_csize, stride_ddA_tile,
     # Meta-parameters
     HAS_SEQ_IDX: tl.constexpr,
+    DETERMINISTIC_REDUCTION: tl.constexpr,
     BLOCK_SIZE_M: tl.constexpr, BLOCK_SIZE_N: tl.constexpr, BLOCK_SIZE_K: tl.constexpr,
     BLOCK_SIZE_DSTATE: tl.constexpr,
 ):
@@ -520,7 +557,7 @@ def _chunk_state_bwd_ddAcs_stable_kernel(
     b_ptr += pid_b * stride_b_batch + pid_c * chunk_size * stride_b_seqlen + (pid_h // nheads_ngroups_ratio) * stride_b_head
     dstates_ptr += pid_b * stride_dstates_batch + pid_c * stride_dstates_chunk + pid_h * stride_states_head
     dt_ptr += pid_b * stride_dt_batch + pid_c * stride_dt_chunk + pid_h * stride_dt_head
-    ddA_cumsum_ptr += pid_b * stride_ddA_cs_batch + pid_c * stride_ddA_cs_chunk + pid_h * stride_ddA_cs_head
+    ddA_cumsum_ptr += pid_b * stride_ddA_cs_batch + pid_c * stride_ddA_cs_chunk + pid_h * stride_ddA_cs_head + pid_n * stride_ddA_tile
     dA_cumsum_ptr += pid_b * stride_dA_cs_batch + pid_c * stride_dA_cs_chunk + pid_h * stride_dA_cs_head
     if HAS_SEQ_IDX:
         seq_idx_ptr += pid_b * stride_seq_idx_batch + pid_c * chunk_size * stride_seq_idx_seqlen
@@ -574,12 +611,19 @@ def _chunk_state_bwd_ddAcs_stable_kernel(
     # ddA_cs = tl.cumsum(ddt * dt_m)
     ddA_cs = ddt * dt_m
     ddA_cumsum_ptrs = ddA_cumsum_ptr + offs_m * stride_ddA_cs_csize
-    # tl.atomic_add(ddA_cumsum_ptrs, ddA_cs, mask=offs_m < chunk_size)
-    tl.atomic_add(ddA_cumsum_ptrs + stride_ddA_cs_csize, ddA_cs, mask=offs_m < chunk_size - 1)
+    if DETERMINISTIC_REDUCTION:
+        tl.store(ddA_cumsum_ptrs + stride_ddA_cs_csize, ddA_cs, mask=offs_m < chunk_size - 1)
+    else:
+        tl.atomic_add(ddA_cumsum_ptrs + stride_ddA_cs_csize, ddA_cs, mask=offs_m < chunk_size - 1)
+
+
+_CHUNK_STATE_BWD_DDACS_MIN_BLOCK_N = min(
+    cfg.kwargs['BLOCK_SIZE_N'] for cfg in _chunk_state_bwd_ddAcs_stable_kernel.configs
+)
 
 
 @triton.autotune(
-    configs=[
+    configs=autotune_configs([
         triton.Config({'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 256, 'BLOCK_SIZE_K': 64}, num_stages=3, num_warps=8),
         triton.Config({'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 256, 'BLOCK_SIZE_K': 32}, num_stages=4, num_warps=4),
         triton.Config({'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 32}, num_stages=4, num_warps=4),
@@ -589,7 +633,7 @@ def _chunk_state_bwd_ddAcs_stable_kernel(
         triton.Config({'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 32, 'BLOCK_SIZE_K': 32}, num_stages=5, num_warps=2),
         triton.Config({'BLOCK_SIZE_M': 32, 'BLOCK_SIZE_N': 64, 'BLOCK_SIZE_K': 32}, num_stages=5, num_warps=2),
         triton.Config({'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 64, 'BLOCK_SIZE_K': 32}, num_stages=4, num_warps=2),
-    ],
+    ]),
     key=['hdim', 'dstate', 'chunk_size'],
 )
 @triton.jit
@@ -703,20 +747,46 @@ def _chunk_cumsum_bwd(ddA, ddt_out, dt, A, dt_bias=None, dt_softplus=False, dt_l
     assert ddA.shape == (batch, nheads, nchunks, chunk_size)
     assert ddt_out.shape == (batch, nheads, nchunks, chunk_size)
     assert A.shape == (nheads,)
+    deterministic = use_deterministic_mode()
     if dt_bias is not None:
         assert dt_bias.shape == (nheads,)
-        ddt_bias = torch.empty_like(dt_bias, dtype=torch.float32)
+        if deterministic:
+            ddt_bias_workspace = torch.zeros(
+                batch, nchunks, nheads, device=dt.device, dtype=torch.float32
+            )
+            ddt_bias = torch.empty_like(dt_bias, dtype=torch.float32)
+            stride_ddt_bias_batch = ddt_bias_workspace.stride(0)
+            stride_ddt_bias_chunk = ddt_bias_workspace.stride(1)
+        else:
+            ddt_bias_workspace = ddt_bias = torch.empty_like(
+                dt_bias, dtype=torch.float32
+            )
+            stride_ddt_bias_batch = 0
+            stride_ddt_bias_chunk = 0
     else:
         ddt_bias = None
+        ddt_bias_workspace = None
+        stride_ddt_bias_batch = 0
+        stride_ddt_bias_chunk = 0
     if ddt is not None:
         assert ddt.shape == dt.shape
     else:
         ddt = torch.empty_like(dt)
     dA = torch.empty_like(A, dtype=torch.float32)
+    if deterministic:
+        dA_workspace = torch.zeros(
+            batch, nchunks, nheads, device=dt.device, dtype=torch.float32
+        )
+        stride_dA_batch = dA_workspace.stride(0)
+        stride_dA_chunk = dA_workspace.stride(1)
+    else:
+        dA_workspace = dA
+        stride_dA_batch = 0
+        stride_dA_chunk = 0
     grid_chunk_cs = lambda META: (batch, nchunks, triton.cdiv(nheads, META['BLOCK_SIZE_H']))
     with torch.cuda.device(dt.device.index):
         _chunk_cumsum_bwd_kernel[grid_chunk_cs](
-            ddA, ddt_out, dt, A, dt_bias, ddt, dA, ddt_bias,
+            ddA, ddt_out, dt, A, dt_bias, ddt, dA_workspace, ddt_bias_workspace if ddt_bias is not None else None,
             batch, seqlen, nheads, chunk_size,
             dt_limit[0], dt_limit[1],
             ddA.stride(0), ddA.stride(2), ddA.stride(1), ddA.stride(3),
@@ -725,12 +795,17 @@ def _chunk_cumsum_bwd(ddA, ddt_out, dt, A, dt_bias=None, dt_softplus=False, dt_l
             A.stride(0),
             dt_bias.stride(0) if dt_bias is not None else 0,
             ddt.stride(0), ddt.stride(1), ddt.stride(2),
-            dA.stride(0),
-            ddt_bias.stride(0) if ddt_bias is not None else 0,
+            stride_dA_batch, stride_dA_chunk, dA_workspace.stride(-1),
+            stride_ddt_bias_batch, stride_ddt_bias_chunk, (ddt_bias_workspace.stride(-1) if ddt_bias is not None else 0),
             dt_softplus,
             HAS_DT_BIAS=dt_bias is not None,
             BLOCK_SIZE_CHUNK=triton.next_power_of_2(chunk_size),
+            DETERMINISTIC_REDUCTION=deterministic,
         )
+    if deterministic:
+        dA.copy_(dA_workspace.sum(dim=(0, 1)))
+        if ddt_bias is not None:
+            ddt_bias.copy_(ddt_bias_workspace.sum(dim=(0, 1)))
     return ddt, dA, ddt_bias
 
 
@@ -780,8 +855,24 @@ def _chunk_state_bwd_dx(B, x, dt, dA_cumsum, dstates, dx=None):
         assert dx.shape == x.shape
     else:
         dx = torch.empty_like(x)
-    ddt = torch.empty(batch, nheads, nchunks, chunk_size, device=dt.device, dtype=torch.float32)
-    ddA_cumsum = torch.empty(batch, nheads, nchunks, chunk_size, device=dA_cumsum.device, dtype=torch.float32)
+    deterministic = use_deterministic_mode()
+    tile_count = math.ceil(headdim / _CHUNK_STATE_BWD_DX_MIN_BLOCK_N)
+    ddt, stride_ddt_tile = alloc_tile_workspace(
+        (batch, nheads, nchunks, chunk_size),
+        tile_count,
+        torch.float32,
+        dt.device,
+        deterministic,
+        zero_init=True,
+    )
+    ddA_cumsum, stride_ddA_tile = alloc_tile_workspace(
+        (batch, nheads, nchunks, chunk_size),
+        tile_count,
+        torch.float32,
+        dA_cumsum.device,
+        deterministic,
+        zero_init=True,
+    )
     grid_dx = lambda META: (triton.cdiv(chunk_size, META['BLOCK_SIZE_M']) * triton.cdiv(headdim, META['BLOCK_SIZE_N']),
                        batch * nchunks, nheads)
     with torch.cuda.device(x.device.index):
@@ -795,11 +886,17 @@ def _chunk_state_bwd_dx(B, x, dt, dA_cumsum, dstates, dx=None):
             dt.stride(0), dt.stride(2), dt.stride(1), dt.stride(3),
             dA_cumsum.stride(0), dA_cumsum.stride(2), dA_cumsum.stride(1), dA_cumsum.stride(3),
             dx.stride(0), dx.stride(1), dx.stride(2), dx.stride(3),
-            ddt.stride(0), ddt.stride(2), ddt.stride(1), ddt.stride(3),
-            ddA_cumsum.stride(0), ddA_cumsum.stride(2), ddA_cumsum.stride(1), ddA_cumsum.stride(3),
+            ddt.stride(0), ddt.stride(2), ddt.stride(1), ddt.stride(3), stride_ddt_tile,
+            ddA_cumsum.stride(0), ddA_cumsum.stride(2), ddA_cumsum.stride(1), ddA_cumsum.stride(3), stride_ddA_tile,
+            DETERMINISTIC_REDUCTION=deterministic,
             BLOCK_SIZE_DSTATE=max(triton.next_power_of_2(dstate), 16),
         )
-    return dx, ddt.to(dt.dtype), ddA_cumsum.to(dA_cumsum.dtype)
+    ddt = finalize_tile_workspace(ddt, deterministic)
+    ddA_cumsum = finalize_tile_workspace(ddA_cumsum, deterministic)
+    if deterministic:
+        # Match `_chunk_state_bwd_dx_kernel` atomic path (`tl.atomic_add(..., ddA_cs_last)` into last element).
+        ddA_cumsum[..., -1] -= ddA_cumsum.sum(dim=-1)
+    return dx, ddt, ddA_cumsum
 
 
 def _chunk_state_bwd_db(x, dt, dA_cumsum, dstates, seq_idx=None, B=None, ngroups=1):
@@ -811,16 +908,31 @@ def _chunk_state_bwd_db(x, dt, dA_cumsum, dstates, seq_idx=None, B=None, ngroups
     assert dstates.shape == (batch, nchunks, nheads, headdim, dstate)
     if seq_idx is not None:
         assert seq_idx.shape == (batch, seqlen)
+    deterministic = use_deterministic_mode()
     if B is not None:
         assert B.shape == (batch, seqlen, ngroups, dstate)
         B_strides = (B.stride(0), B.stride(1), B.stride(2), B.stride(3))
         # Use torch.empty since the Triton kernel will call init_to_zero
-        ddA_cumsum = torch.empty(batch, nheads, nchunks, chunk_size, device=x.device, dtype=torch.float32)
-        ddA_cumsum_strides = (ddA_cumsum.stride(0), ddA_cumsum.stride(2), ddA_cumsum.stride(1), ddA_cumsum.stride(3))
+        tile_count = math.ceil(dstate / _CHUNK_STATE_BWD_DB_MIN_BLOCK_N)
+        ddA_cumsum, stride_ddA_tile = alloc_tile_workspace(
+            (batch, nheads, nchunks, chunk_size),
+            tile_count,
+            torch.float32,
+            x.device,
+            deterministic,
+            zero_init=True,
+        )
+        ddA_cumsum_strides = (
+            ddA_cumsum.stride(0),
+            ddA_cumsum.stride(2),
+            ddA_cumsum.stride(1),
+            ddA_cumsum.stride(3),
+        )
     else:
         B_strides = (0, 0, 0, 0)
         ddA_cumsum = None
         ddA_cumsum_strides = (0, 0, 0, 0)
+        stride_ddA_tile = 0
     nheads_ngroups_ratio = nheads // ngroups
     sm_count = torch.cuda.get_device_properties(x.device).multi_processor_count
     nheads_per_program = max(min(math.ceil(batch * nchunks * nheads / sm_count), nheads_ngroups_ratio), 1)
@@ -840,13 +952,15 @@ def _chunk_state_bwd_db(x, dt, dA_cumsum, dstates, seq_idx=None, B=None, ngroups
             dA_cumsum.stride(0), dA_cumsum.stride(2), dA_cumsum.stride(1), dA_cumsum.stride(3),
             *((seq_idx.stride(0), seq_idx.stride(1)) if seq_idx is not None else (0, 0)),
             dB.stride(0), dB.stride(1), dB.stride(2), dB.stride(3), dB.stride(4),
-            *ddA_cumsum_strides,
+            *ddA_cumsum_strides, stride_ddA_tile,
             HAS_DDA_CS=ddA_cumsum is not None,
             HAS_SEQ_IDX=seq_idx is not None,
+            DETERMINISTIC_REDUCTION=deterministic,
             BLOCK_SIZE_K=max(triton.next_power_of_2(headdim), 16),
         )
     dB = dB.sum(2)
     if ddA_cumsum is not None:
+        ddA_cumsum = finalize_tile_workspace(ddA_cumsum, deterministic)
         # The first element of ddA_cumsum is always zero, since that dA_cumsum does not contribute
         # to the state of the chunk.
         # torch.cumsum(ddA_cumsum[..., 1:], dim=-1, out=ddA_cumsum[..., 1:])
@@ -867,7 +981,16 @@ def _chunk_state_bwd_ddAcs_stable(B, x, dt, dA_cumsum, dstates, seq_idx=None):
     if seq_idx is not None:
         assert seq_idx.shape == (batch, seqlen)
     # Use torch.empty since the Triton kernel will call init_to_zero
-    ddA_cumsum = torch.empty(batch, nheads, nchunks, chunk_size, device=x.device, dtype=torch.float32)
+    deterministic = use_deterministic_mode()
+    tile_count = math.ceil(headdim / _CHUNK_STATE_BWD_DDACS_MIN_BLOCK_N)
+    ddA_cumsum, stride_ddA_tile = alloc_tile_workspace(
+        (batch, nheads, nchunks, chunk_size),
+        tile_count,
+        torch.float32,
+        x.device,
+        deterministic,
+        zero_init=True,
+    )
     grid_ddtcs = lambda META: (triton.cdiv(chunk_size, META['BLOCK_SIZE_M']) * triton.cdiv(headdim, META['BLOCK_SIZE_N']),
                           batch * nchunks, nheads)
     with torch.cuda.device(x.device.index):
@@ -881,11 +1004,13 @@ def _chunk_state_bwd_ddAcs_stable(B, x, dt, dA_cumsum, dstates, seq_idx=None):
             dt.stride(0), dt.stride(2), dt.stride(1), dt.stride(3),
             dA_cumsum.stride(0), dA_cumsum.stride(2), dA_cumsum.stride(1), dA_cumsum.stride(3),
             *((seq_idx.stride(0), seq_idx.stride(1)) if seq_idx is not None else (0, 0)),
-            ddA_cumsum.stride(0), ddA_cumsum.stride(2), ddA_cumsum.stride(1), ddA_cumsum.stride(3),
+            ddA_cumsum.stride(0), ddA_cumsum.stride(2), ddA_cumsum.stride(1), ddA_cumsum.stride(3), stride_ddA_tile,
             HAS_SEQ_IDX=seq_idx is not None,
+            DETERMINISTIC_REDUCTION=deterministic,
             BLOCK_SIZE_M=max(triton.next_power_of_2(chunk_size), 16),
             BLOCK_SIZE_DSTATE=max(triton.next_power_of_2(dstate), 16),
         )
+    ddA_cumsum = finalize_tile_workspace(ddA_cumsum, deterministic)
     torch.cumsum(ddA_cumsum[..., 1:], dim=-1, out=ddA_cumsum[..., 1:])
     return ddA_cumsum
 

--- a/mamba_ssm/ops/triton/ssd_chunk_state.py
+++ b/mamba_ssm/ops/triton/ssd_chunk_state.py
@@ -233,7 +233,7 @@ def _chunk_state_fwd_kernel(
             scale = tl.exp(tl.minimum((dA_cs_last - dA_cs_k), 0.0)) * dt_k
         else:
             # scale = tl.where(seq_idx_k == seq_idx_last, tl.exp((dA_cs_last - dA_cs_k)) * dt_k, 0.0)
-            scale = tl.where(seq_idx_k == seq_idx_last, tl.exp(tl.minimum((dA_cs_last - dA_cs_k), 0.0)) * dt_k, 0.0)
+            scale = tl.where((seq_idx_last >= 0) & (seq_idx_k == seq_idx_last), tl.exp(tl.minimum((dA_cs_last - dA_cs_k), 0.0)) * dt_k, 0.0)
         b *= scale[:, None]
         b = b.to(x_ptr.dtype.element_ty)
         acc += tl.dot(x, b)

--- a/mamba_ssm/ops/triton/ssd_state_passing.py
+++ b/mamba_ssm/ops/triton/ssd_state_passing.py
@@ -12,16 +12,18 @@ import triton.language as tl
 
 from einops import rearrange, repeat
 
+from mamba_ssm.utils.determinism import autotune_configs
+
 
 @triton.autotune(
-    configs=[
+    configs=autotune_configs([
         triton.Config({'BLOCK_SIZE': 64}),
         triton.Config({'BLOCK_SIZE': 128}),
         triton.Config({'BLOCK_SIZE': 256}),
         triton.Config({'BLOCK_SIZE': 512}),
         triton.Config({'BLOCK_SIZE': 1024}),
         triton.Config({'BLOCK_SIZE': 2048}),
-    ],
+    ]),
     key=['dim'],
 )
 @triton.jit
@@ -86,14 +88,14 @@ def _state_passing_fwd_kernel(
 
 
 @triton.autotune(
-    configs=[
+    configs=autotune_configs([
         triton.Config({'BLOCK_SIZE': 64}),
         triton.Config({'BLOCK_SIZE': 128}),
         triton.Config({'BLOCK_SIZE': 256}),
         triton.Config({'BLOCK_SIZE': 512}),
         triton.Config({'BLOCK_SIZE': 1024}),
         triton.Config({'BLOCK_SIZE': 2048}),
-    ],
+    ]),
     key=['dim'],
 )
 @triton.jit

--- a/mamba_ssm/utils/determinism.py
+++ b/mamba_ssm/utils/determinism.py
@@ -1,0 +1,96 @@
+# Copyright (c) 2024, Tri Dao, Albert Gu.
+
+import os
+import warnings
+from packaging import version
+
+import torch
+
+try:
+    import triton
+    TRITON_VERSION = version.parse(triton.__version__)
+except ImportError:
+    TRITON_VERSION = version.parse("0.0.0")
+
+TRITON_HAS_CACHE_RESULTS = TRITON_VERSION >= version.parse("3.4.0")
+_autotune_warning_issued = False
+
+_deterministic_override = None
+
+
+def use_deterministic_mode():
+    if _deterministic_override is not None:
+        return _deterministic_override
+    env = os.environ.get('MAMBA_DETERMINISTIC')
+    if env:
+        return env[0] == '1'
+    return torch.are_deterministic_algorithms_enabled()
+
+
+def set_deterministic_mode(value):
+    global _deterministic_override
+    _deterministic_override = value
+
+
+def _estimate_config_cost(cfg):
+    """Estimate shared memory cost of a config. Lower is cheaper."""
+    block_product = 1
+    for key, val in cfg.kwargs.items():
+        if key.startswith('BLOCK_SIZE_'):
+            block_product *= val
+    return block_product * (getattr(cfg, 'num_stages', 1) or 1)
+
+
+def _filter_configs_by_block_sizes(configs):
+    """Filter configs by TRITON_AUTOTUNE_BLOCK_SIZE_* env vars."""
+    env_filters = {}
+    for suffix in ('M', 'N', 'K', 'DSTATE'):
+        env_val = os.environ.get(f"TRITON_AUTOTUNE_BLOCK_SIZE_{suffix}")
+        if env_val is not None:
+            env_filters[f'BLOCK_SIZE_{suffix}'] = int(env_val)
+    if not env_filters:
+        return None
+    matching = configs
+    for key, target in env_filters.items():
+        matching = [c for c in matching if c.kwargs.get(key) == target]
+    return matching[:1] if matching else None
+
+
+def autotune_configs(configs):
+    """Select autotune configs for deterministic mode.
+    
+    Uses cached autotuning (TRITON_CACHE_AUTOTUNING=1) if Triton >= 3.4.0,
+    otherwise auto-selects the cheapest config by block size * stages.
+    """
+    if not configs or not use_deterministic_mode():
+        return configs
+    if TRITON_HAS_CACHE_RESULTS and os.environ.get("TRITON_CACHE_AUTOTUNING") == "1":
+        return configs
+    global _autotune_warning_issued
+    if not _autotune_warning_issued:
+        _autotune_warning_issued = True
+        msg = "Deterministic mode: set TRITON_CACHE_AUTOTUNING=1 for cached autotuning." if TRITON_HAS_CACHE_RESULTS else "Deterministic mode: upgrade to Triton >= 3.4.0 for cached autotuning."
+        warnings.warn(msg)
+    filtered = _filter_configs_by_block_sizes(configs)
+    if filtered:
+        return filtered
+    return [min(configs, key=_estimate_config_cost)]
+
+
+def alloc_tile_workspace(base_shape, tile_dim, dtype, device, deterministic, *, zero_init=True):
+    """Allocate buffer for deterministic per-program reductions."""
+    if base_shape is None:
+        return None, 0
+    if deterministic:
+        factory = torch.zeros if zero_init else torch.empty
+        tensor = factory(*base_shape, tile_dim, device=device, dtype=dtype)
+        return tensor, tensor.stride(-1)
+    return torch.empty(*base_shape, device=device, dtype=dtype), 0
+
+
+def finalize_tile_workspace(tensor, deterministic):
+    if tensor is None:
+        return None
+    if deterministic:
+        tensor = tensor.sum(dim=-1)
+    return tensor

--- a/mamba_ssm/utils/generation.py
+++ b/mamba_ssm/utils/generation.py
@@ -11,7 +11,7 @@ import torch.nn.functional as F
 from einops import rearrange, repeat
 from torch import Tensor
 from torch.profiler import ProfilerActivity, profile, record_function
-from transformers.generation import GreedySearchDecoderOnlyOutput, SampleDecoderOnlyOutput, TextStreamer
+from transformers.generation import GenerateDecoderOnlyOutput, TextStreamer
 
 
 @dataclass
@@ -146,7 +146,7 @@ def decode(
         max_length: int
         teacher_outputs (optional): (batch, seq_len). If provided, instead of sampling from the
             logits, the next token is taken from the teacher_outputs. Useful for testing.
-    Returns: GreedySearchDecoderOnlyOutput or SampleDecoderOnlyOutput, with the following fields:
+    Returns: GenerateDecoderOnlyOutput, with the following fields:
         sequences: (batch, max_length)
         scores: tuples of (batch, vocab_size)
     """
@@ -240,8 +240,7 @@ def decode(
         end.record()
         torch.cuda.synchronize()
         print(f"Prompt processing + decoding time: {(start.elapsed_time(end)):.0f}ms")
-    output_cls = GreedySearchDecoderOnlyOutput if top_k == 1 else SampleDecoderOnlyOutput
-    return output_cls(sequences=torch.cat(sequences, dim=1), scores=tuple(scores))
+    return GenerateDecoderOnlyOutput(sequences=torch.cat(sequences, dim=1), scores=tuple(scores))
 
 
 class GenerationMixin:

--- a/setup.py
+++ b/setup.py
@@ -293,7 +293,15 @@ def get_wheel_url():
         torch_cuda_version = parse(torch.version.cuda)
         # For CUDA 11, we only compile for CUDA 11.8, and for CUDA 12 we only compile for CUDA 12.3
         # to save CI time. Minor versions should be compatible.
-        torch_cuda_version = parse("11.8") if torch_cuda_version.major == 11 else parse("12.3")
+        if torch_cuda_version.major == 11:
+            torch_cuda_version = parse("11.8")
+        elif torch_cuda_version.major == 12:
+            torch_cuda_version = parse("12.3")
+        elif torch_cuda_version.major == 13:
+            torch_cuda_version = parse("13.0")
+        else:
+            raise ValueError(f"CUDA version {torch_cuda_version} not supported")
+        
         cuda_version = f"{torch_cuda_version.major}"
 
     gpu_compute_version = hip_ver if HIP_BUILD else cuda_version

--- a/tests/benchmark_determinism_kernels.py
+++ b/tests/benchmark_determinism_kernels.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python
+# Copyright (c) 2024, Tri Dao, Albert Gu.
+
+import gc
+import math
+
+import torch
+from triton.testing import do_bench
+
+from mamba_ssm.utils.determinism import set_deterministic_mode
+
+MODEL_PRESETS = {
+    "small": {"nheads": 32, "headdim": 64, "dstate": 64, "ngroups": 1},
+    "nemotronh-56b": {"nheads": 256, "headdim": 64, "dstate": 256, "ngroups": 8},
+}
+
+
+def _reset_peak_memory() -> None:
+    gc.collect()
+    torch.cuda.empty_cache()
+    torch.cuda.reset_peak_memory_stats()
+    torch.cuda.synchronize()
+
+
+def _peak_memory_mb(fn, *, warmup: int = 3) -> float:
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    _reset_peak_memory()
+    fn()
+    torch.cuda.synchronize()
+    return torch.cuda.max_memory_allocated() / (1024 * 1024)
+
+
+def make_tensors(*, batch: int, seqlen: int, nheads: int, headdim: int, dstate: int, ngroups: int, chunk_size: int,
+                 dtype: torch.dtype = torch.bfloat16) -> dict[str, torch.Tensor]:
+    device = "cuda"
+    nchunks = math.ceil(seqlen / chunk_size)
+    return {
+        "x": torch.randn(batch, seqlen, nheads, headdim, device=device, dtype=dtype),
+        "B": torch.randn(batch, seqlen, ngroups, dstate, device=device, dtype=dtype),
+        "C": torch.randn(batch, seqlen, ngroups, dstate, device=device, dtype=dtype),
+        "dt": torch.randn(batch, nheads, nchunks, chunk_size, device=device, dtype=torch.float32),
+        "dA_cumsum": torch.randn(batch, nheads, nchunks, chunk_size, device=device, dtype=torch.float32),
+        "dstates": torch.randn(batch, nchunks, nheads, headdim, dstate, device=device, dtype=torch.float32),
+        "dout": torch.randn(batch, seqlen, nheads, headdim, device=device, dtype=dtype),
+        "ddA": torch.randn(batch, nheads, nchunks, chunk_size, device=device, dtype=torch.float32),
+        "ddt_out": torch.randn(batch, nheads, nchunks, chunk_size, device=device, dtype=torch.float32),
+        "dt_raw": torch.randn(batch, seqlen, nheads, device=device, dtype=dtype),
+        "A": torch.randn(nheads, device=device, dtype=torch.float32) * -1,
+        "dt_bias": torch.randn(nheads, device=device, dtype=torch.float32),
+        "prev_states": torch.randn(batch, nchunks, nheads, headdim, dstate, device=device, dtype=torch.float32),
+        "cb": torch.randn(batch, nchunks, ngroups, chunk_size, chunk_size, device=device, dtype=dtype),
+    }
+
+
+def get_benchmarks(t: dict[str, torch.Tensor], *, ngroups: int):
+    from mamba_ssm.ops.triton.ssd_chunk_state import (
+        _chunk_cumsum_bwd,
+        _chunk_state_bwd_db,
+        _chunk_state_bwd_ddAcs_stable,
+        _chunk_state_bwd_dx,
+    )
+    from mamba_ssm.ops.triton.ssd_chunk_scan import _chunk_scan_bwd_dC, _chunk_scan_bwd_dx
+    from mamba_ssm.ops.triton.ssd_combined import _chunk_scan_chunk_state_bwd_dx
+
+    x = t["x"].contiguous()
+    B = t["B"].contiguous()
+    C = t["C"].contiguous()
+    dout = t["dout"].contiguous()
+    dstates = t["dstates"].contiguous()
+
+    return [
+        ("chunk_cumsum_bwd", lambda: _chunk_cumsum_bwd(t["ddA"], t["ddt_out"], t["dt_raw"], t["A"], dt_bias=t["dt_bias"], dt_softplus=True)),
+        ("chunk_state_bwd_dx", lambda: _chunk_state_bwd_dx(B, x, t["dt"], t["dA_cumsum"], dstates)),
+        ("chunk_state_bwd_db", lambda: _chunk_state_bwd_db(x, t["dt"], t["dA_cumsum"], dstates, B=B, ngroups=ngroups)),
+        ("chunk_state_bwd_ddAcs", lambda: _chunk_state_bwd_ddAcs_stable(B, x, t["dt"], t["dA_cumsum"], dstates)),
+        ("chunk_scan_bwd_dC", lambda: _chunk_scan_bwd_dC(t["prev_states"], t["dA_cumsum"], dout, C=C, ngroups=ngroups)),
+        ("chunk_scan_bwd_dx", lambda: _chunk_scan_bwd_dx(t["cb"], x, t["dt"], t["dA_cumsum"], dout)),
+        ("combined_bwd_dx", lambda: _chunk_scan_chunk_state_bwd_dx(x, t["dt"], t["dA_cumsum"], B, t["cb"], dout, dstates)),
+    ]
+
+
+def _run_one(fn, *, deterministic: bool, warmup: int, rep: int):
+    set_deterministic_mode(deterministic)
+    ms = do_bench(fn, warmup=warmup, rep=rep, return_mode="median")
+    peak_mb = _peak_memory_mb(fn, warmup=1)
+    return ms, peak_mb
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Benchmark determinism overhead for key Triton backward kernels")
+    parser.add_argument("--preset", choices=sorted(MODEL_PRESETS.keys()), default="small")
+    parser.add_argument("--warmup", type=int, default=25)
+    parser.add_argument("--rep", type=int, default=100)
+    parser.add_argument("--batch", type=int, default=4)
+    parser.add_argument("--seqlen", type=int, default=2048)
+    parser.add_argument("--chunk-size", type=int, default=256)
+    args = parser.parse_args()
+
+    if not torch.cuda.is_available():
+        raise SystemExit("CUDA not available")
+
+    p = MODEL_PRESETS[args.preset]
+    tensors = make_tensors(
+        batch=args.batch,
+        seqlen=args.seqlen,
+        nheads=p["nheads"],
+        headdim=p["headdim"],
+        dstate=p["dstate"],
+        ngroups=p["ngroups"],
+        chunk_size=args.chunk_size,
+    )
+    benches = get_benchmarks(tensors, ngroups=p["ngroups"])
+
+    print(f"GPU: {torch.cuda.get_device_name(0)}")
+    print(f"preset={args.preset} batch={args.batch} seqlen={args.seqlen} chunk_size={args.chunk_size}")
+    print(f"{'kernel':<20} {'ms':>9} {'det_ms':>9} {'ms_%':>6} {'MB':>9} {'det_MB':>9} {'MB_%':>6}")
+
+    rows = []
+    try:
+        for name, fn in benches:
+            ms, mb = _run_one(fn, deterministic=False, warmup=args.warmup, rep=args.rep)
+            det_ms, det_mb = _run_one(fn, deterministic=True, warmup=args.warmup, rep=args.rep)
+            ms_pct = (det_ms / ms - 1.0) * 100.0
+            mb_pct = (det_mb / mb - 1.0) * 100.0 if mb else 0.0
+            rows.append((name, ms, det_ms, ms_pct, mb, det_mb, mb_pct))
+            print(f"{name:<20} {ms:>9.3f} {det_ms:>9.3f} {ms_pct:>+6.0f}% {mb:>9.1f} {det_mb:>9.1f} {mb_pct:>+6.0f}%")
+    finally:
+        set_deterministic_mode(None)
+
+    total_ms = sum(r[1] for r in rows)
+    total_det_ms = sum(r[2] for r in rows)
+    max_mb = max(r[4] for r in rows) if rows else 0.0
+    max_det_mb = max(r[5] for r in rows) if rows else 0.0
+    total_pct = (total_det_ms / total_ms - 1.0) * 100.0 if total_ms else 0.0
+    max_mb_pct = (max_det_mb / max_mb - 1.0) * 100.0 if max_mb else 0.0
+    print(f"{'TOTAL/MAX':<20} {total_ms:>9.3f} {total_det_ms:>9.3f} {total_pct:>+6.0f}% {max_mb:>9.1f} {max_det_mb:>9.1f} {max_mb_pct:>+6.0f}%")
+
+
+if __name__ == "__main__":
+    main()
+
+

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -1,0 +1,342 @@
+# Copyright (c) 2024, Tri Dao, Albert Gu.
+
+import os
+
+import pytest
+import torch
+
+
+def _set_deterministic(enabled: bool) -> None:
+    torch.use_deterministic_algorithms(enabled)
+    if enabled:
+        os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"
+
+
+def _set_seeds(seed: int) -> None:
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+
+
+def _max_abs_diff(a: torch.Tensor, b: torch.Tensor) -> float:
+    return (a.float() - b.float()).abs().max().item()
+
+
+def _make_inputs(
+    *,
+    seed: int,
+    headdim: int,
+    dstate: int,
+    chunk_size: int = 256,
+    ngroups: int = 1,
+    dtype: torch.dtype = torch.bfloat16,
+    d_has_hdim: bool = False,
+) -> dict[str, torch.Tensor]:
+    import math
+
+    _set_seeds(seed)
+    device = "cuda"
+
+    batch = 2
+    seqlen = 2048
+    nheads = 8
+    nchunks = math.ceil(seqlen / chunk_size)
+
+    x = torch.randn(batch, seqlen, nheads, headdim, device=device, dtype=dtype)
+    dout = torch.randn_like(x)
+    dt = torch.randn(batch, nheads, nchunks, chunk_size, device=device, dtype=torch.float32)
+    dA_cumsum = torch.randn_like(dt)
+    cb = torch.randn(batch, nchunks, ngroups, chunk_size, chunk_size, device=device, dtype=dtype)
+
+    B = torch.randn(batch, seqlen, ngroups, dstate, device=device, dtype=dtype).contiguous()
+    C = torch.randn(batch, seqlen, ngroups, dstate, device=device, dtype=dtype).contiguous()
+    dstates = torch.randn(batch, nchunks, nheads, headdim, dstate, device=device, dtype=torch.float32)
+    prev_states = torch.randn_like(dstates)
+
+    ddA = torch.randn(batch, nheads, nchunks, chunk_size, device=device, dtype=torch.float32)
+    ddt_out = torch.randn_like(ddA)
+    dt_raw = torch.randn(batch, seqlen, nheads, device=device, dtype=dtype)
+    A = (torch.randn(nheads, device=device, dtype=torch.float32) * -1.0).contiguous()
+    dt_bias = torch.randn(nheads, device=device, dtype=torch.float32).contiguous()
+    # D shape: (nheads, headdim) when d_has_hdim=True, else (nheads,)
+    if d_has_hdim:
+        D = torch.randn(nheads, headdim, device=device, dtype=torch.float32)
+    else:
+        D = torch.randn(nheads, device=device, dtype=torch.float32)
+
+    return {
+        "x": x,
+        "dout": dout,
+        "dt": dt,
+        "dA_cumsum": dA_cumsum,
+        "cb": cb,
+        "B": B,
+        "C": C,
+        "dstates": dstates,
+        "prev_states": prev_states,
+        "ddA": ddA,
+        "ddt_out": ddt_out,
+        "dt_raw": dt_raw,
+        "A": A,
+        "dt_bias": dt_bias,
+        "D": D,
+    }
+
+
+def _run_case_outputs(
+    *,
+    case: str,
+    deterministic: bool,
+    seed: int,
+    headdim: int = 64,
+    dstate: int = 64,
+    chunk_size: int = 256,
+    ngroups: int = 1,
+    dtype: torch.dtype = torch.bfloat16,
+    d_has_hdim: bool = False,
+) -> dict[str, torch.Tensor]:
+    _set_deterministic(deterministic)
+    t = _make_inputs(
+        seed=seed,
+        headdim=headdim,
+        dstate=dstate,
+        chunk_size=chunk_size,
+        ngroups=ngroups,
+        dtype=dtype,
+        d_has_hdim=d_has_hdim,
+    )
+
+    if case == "chunk_scan_bwd_dx":
+        from mamba_ssm.ops.triton.ssd_chunk_scan import _chunk_scan_bwd_dx
+        dx, ddt = _chunk_scan_bwd_dx(t["cb"], t["x"], t["dt"], t["dA_cumsum"], t["dout"])
+        out = {"dx": dx, "ddt": ddt}
+    elif case == "chunk_scan_bwd_dC":
+        from mamba_ssm.ops.triton.ssd_chunk_scan import _chunk_scan_bwd_dC
+        dC, ddA_prev = _chunk_scan_bwd_dC(t["prev_states"], t["dA_cumsum"], t["dout"], C=t["C"], ngroups=1)
+        out = {"dC": dC, "ddA_cumsum_prev": ddA_prev}
+    elif case == "chunk_state_bwd_dx":
+        from mamba_ssm.ops.triton.ssd_chunk_state import _chunk_state_bwd_dx
+        dx, ddt, ddA = _chunk_state_bwd_dx(t["B"], t["x"], t["dt"], t["dA_cumsum"], t["dstates"])
+        out = {"dx": dx, "ddt": ddt, "ddA_cumsum": ddA}
+    elif case == "chunk_state_bwd_db":
+        from mamba_ssm.ops.triton.ssd_chunk_state import _chunk_state_bwd_db
+        dB, ddA = _chunk_state_bwd_db(t["x"], t["dt"], t["dA_cumsum"], t["dstates"], B=t["B"], ngroups=1)
+        out = {"dB": dB, "ddA_cumsum": ddA}
+    elif case == "chunk_state_bwd_ddAcs_stable":
+        from mamba_ssm.ops.triton.ssd_chunk_state import _chunk_state_bwd_ddAcs_stable
+        ddA = _chunk_state_bwd_ddAcs_stable(t["B"], t["x"], t["dt"], t["dA_cumsum"], t["dstates"])
+        out = {"ddA_cumsum": ddA}
+    elif case == "chunk_cumsum_bwd":
+        from mamba_ssm.ops.triton.ssd_chunk_state import _chunk_cumsum_bwd
+        ddt, dA, ddt_bias = _chunk_cumsum_bwd(t["ddA"], t["ddt_out"], t["dt_raw"], t["A"], dt_bias=t["dt_bias"], dt_softplus=True)
+        out = {"ddt": ddt, "dA": dA, "ddt_bias": ddt_bias}
+    elif case.startswith("combined_bwd_dx"):
+        from mamba_ssm.ops.triton.ssd_combined import _chunk_scan_chunk_state_bwd_dx
+        dx, ddt, dD = _chunk_scan_chunk_state_bwd_dx(t["x"], t["dt"], t["dA_cumsum"], t["B"], t["cb"], t["dout"], t["dstates"], D=t["D"])
+        out = {"dx": dx, "ddt": ddt, "dD": dD}
+    else:
+        raise AssertionError(f"Unknown case: {case}")
+
+    torch.cuda.synchronize()
+    return {k: v.detach().clone().float() for k, v in out.items() if v is not None}
+
+
+_KERNEL_CASES = [
+    "chunk_scan_bwd_dx",
+    "chunk_scan_bwd_dC",
+    "chunk_state_bwd_dx",
+    "chunk_state_bwd_db",
+    "chunk_state_bwd_ddAcs_stable",
+    "chunk_cumsum_bwd",
+]
+
+_COMBINED_CASES = [
+    ("combined_bwd_dx", False),
+    ("combined_bwd_dx_d_hdim", True),
+]
+
+_HEADDIMS = [64, 128]
+_DSTATES = [64]
+
+
+def _kernel_is_reproducible(case: str, headdim: int, dstate: int, d_has_hdim: bool = False):
+    runs = 5
+    outs = [
+        _run_case_outputs(case=case, deterministic=True, seed=123, headdim=headdim, dstate=dstate, d_has_hdim=d_has_hdim)
+        for _ in range(runs)
+    ]
+    ref = outs[0]
+    for i in range(1, runs):
+        for k in ref:
+            assert _max_abs_diff(ref[k], outs[i][k]) == 0.0, f"{case} output {k} differs (headdim={headdim}, dstate={dstate})"
+
+
+def _kernel_close_to_default(case: str, headdim: int, dstate: int, d_has_hdim: bool = False):
+    atol = rtol = 1e-2
+    det = _run_case_outputs(case=case, deterministic=True, seed=123, headdim=headdim, dstate=dstate, d_has_hdim=d_has_hdim)
+    for _ in range(3):
+        default = _run_case_outputs(case=case, deterministic=False, seed=123, headdim=headdim, dstate=dstate, d_has_hdim=d_has_hdim)
+        for k in det:
+            assert torch.allclose(default[k], det[k], atol=atol, rtol=rtol), f"{case} output {k} not close (headdim={headdim}, dstate={dstate})"
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize("dstate", _DSTATES)
+@pytest.mark.parametrize("headdim", _HEADDIMS)
+@pytest.mark.parametrize("case", _KERNEL_CASES)
+def test_kernel_reproducible(case: str, headdim: int, dstate: int):
+    _kernel_is_reproducible(case, headdim, dstate)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize("dstate", _DSTATES)
+@pytest.mark.parametrize("headdim", _HEADDIMS)
+@pytest.mark.parametrize("case,d_has_hdim", _COMBINED_CASES)
+def test_combined_kernel_reproducible(case: str, d_has_hdim: bool, headdim: int, dstate: int):
+    _kernel_is_reproducible(case, headdim, dstate, d_has_hdim)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize("dstate", _DSTATES)
+@pytest.mark.parametrize("headdim", _HEADDIMS)
+@pytest.mark.parametrize("case", _KERNEL_CASES)
+def test_kernel_close_to_default(case: str, headdim: int, dstate: int):
+    _kernel_close_to_default(case, headdim, dstate)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+@pytest.mark.parametrize("dstate", _DSTATES)
+@pytest.mark.parametrize("headdim", _HEADDIMS)
+@pytest.mark.parametrize("case,d_has_hdim", _COMBINED_CASES)
+def test_combined_kernel_close_to_default(case: str, d_has_hdim: bool, headdim: int, dstate: int):
+    _kernel_close_to_default(case, headdim, dstate, d_has_hdim)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_default_mode_is_not_reproducible():
+    from mamba_ssm.modules.mamba2 import Mamba2
+
+    device = "cuda"
+    dtype = torch.bfloat16
+    seed = 123
+    runs = 20
+    batch = 4
+    seqlen = 4096
+
+    _set_seeds(seed)
+    model = Mamba2(
+        d_model=256, d_state=64, headdim=64, expand=2, d_conv=4, chunk_size=256,
+        use_mem_eff_path=True, device=device, dtype=dtype,
+    ).train()
+    x_data = torch.randn(batch, seqlen, model.d_model, device=device, dtype=dtype)
+
+    def _run() -> dict[str, torch.Tensor]:
+        _set_deterministic(False)
+        model.zero_grad(set_to_none=True)
+        x = x_data.clone().requires_grad_(True)
+        y = model(x)
+        (y.float().square().mean()).backward()
+        torch.cuda.synchronize()
+        grads = {"input": x.grad.detach().float().clone()}
+        for name, p in model.named_parameters():
+            if p.grad is not None:
+                grads[name] = p.grad.detach().float().clone()
+        return grads
+
+    _run()  # warmup
+    ref = _run()
+    observed_diff = False
+    for _ in range(runs - 1):
+        g = _run()
+        for k in ref:
+            if _max_abs_diff(ref[k], g[k]) != 0.0:
+                observed_diff = True
+                break
+        if observed_diff:
+            break
+
+    if not observed_diff:
+        pytest.xfail(
+            f"Did not observe nondeterminism in default mode after {runs} runs. "
+            "This GPU may have deterministic atomic behavior at these shapes."
+        )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_mamba2_fwd_bwd_deterministic_reproducible():
+    from mamba_ssm.modules.mamba2 import Mamba2
+
+    device = "cuda"
+    dtype = torch.bfloat16
+    seed = 123
+    runs = 5
+    batch = 2
+    seqlen = 2048
+    headdim = 64
+
+    _set_seeds(seed)
+    _set_deterministic(True)
+
+    model = Mamba2(
+        d_model=headdim, d_state=16, headdim=headdim, expand=2, d_conv=4, chunk_size=16,
+        use_mem_eff_path=True, device=device, dtype=dtype,
+    ).train()
+    x_data = torch.randn(batch, seqlen, model.d_model, device=device, dtype=dtype)
+
+    def _run() -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
+        model.zero_grad(set_to_none=True)
+        x = x_data.clone().requires_grad_(True)
+        y = model(x)
+        (y.float().square().mean()).backward()
+        torch.cuda.synchronize()
+        grads: dict[str, torch.Tensor] = {"input": x.grad.detach().float().clone()}
+        for name, p in model.named_parameters():
+            if p.grad is not None:
+                grads[name] = p.grad.detach().float().clone()
+        return y.detach().float().clone(), grads
+
+    _run()  # warmup
+    y0, g0 = _run()
+    for _ in range(runs - 1):
+        y, g = _run()
+        assert _max_abs_diff(y0, y) == 0.0
+        assert g.keys() == g0.keys()
+        for k in g0:
+            assert _max_abs_diff(g0[k], g[k]) == 0.0, f"Mamba2 grad {k} differs"
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+def test_mamba2_fwd_bwd_deterministic_close_to_default():
+    from mamba_ssm.modules.mamba2 import Mamba2
+
+    device = "cuda"
+    dtype = torch.bfloat16
+    seed = 123
+    batch = 2
+    seqlen = 2048
+    headdim = 64
+    atol = rtol = 1e-2
+
+    def _run(deterministic: bool) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
+        torch.use_deterministic_algorithms(deterministic, warn_only=True)
+        _set_seeds(seed)
+        model = Mamba2(
+            d_model=headdim * 4, d_state=32, headdim=headdim, expand=2, d_conv=4, chunk_size=64,
+            use_mem_eff_path=True, device=device, dtype=dtype,
+        ).train()
+        x = torch.randn(batch, seqlen, model.d_model, device=device, dtype=dtype).requires_grad_(True)
+        y = model(x)
+        (y.float().square().mean()).backward()
+        torch.cuda.synchronize()
+        grads: dict[str, torch.Tensor] = {"input": x.grad.detach().float().clone()}
+        for name, p in model.named_parameters():
+            if p.grad is not None:
+                grads[name] = p.grad.detach().float().clone()
+        return y.detach().float().clone(), grads
+
+    _run(False)  # warmup
+    y_default, g_default = _run(False)
+    y_det, g_det = _run(True)
+
+    assert torch.allclose(y_default, y_det, atol=atol, rtol=rtol), "Mamba2 output differs"
+    for k in g_default:
+        assert torch.allclose(g_default[k], g_det[k], atol=atol, rtol=rtol), f"Mamba2 grad {k} not close"

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -111,3 +111,83 @@ def test_generation_varlen():
     out_varlen = torch.cat(scores, dim=1)
     print(f"Max diff: {(out_varlen - out_ref).abs().max()}")
     assert (out_varlen - out_ref).abs().max() < 2 * (out_loop - out_ref).abs().max()
+
+def test_generation_varlen_with_padding():
+    seqlens = [170, 65, 100]
+    non_padded_seqlen = sum(seqlens)
+    padded_seqlen = 512
+    seqlens.append(padded_seqlen - non_padded_seqlen)
+    genlen = 20
+    total_seqlen = sum(seqlens)
+    assert total_seqlen == padded_seqlen
+    device = "cuda"
+    dtype = torch.float16
+
+    config = MambaConfig(
+        d_model=1024,
+        n_layer=4,
+        vocab_size=50277,
+        ssm_cfg=dict(layer="Mamba2"),
+        rms_norm=True,
+        residual_in_fp32=True,
+        fused_add_norm=True,
+        pad_vocab_size_multiple=16,
+    )
+    torch.manual_seed(2357)
+    model = MambaLMHeadModel(config, device=device, dtype=dtype)
+    xs = [torch.randint(0, 1000, (1, seqlen), device=device, dtype=torch.long) for seqlen in seqlens]
+
+    # Reference 1: Forward pass with seq_idx
+    x = torch.cat(xs[:-1], dim=1)
+    seq_idx = torch.cat([torch.full((ids.shape[1],), i, dtype=torch.int32, device=device)
+                         for i, ids in enumerate(xs[:-1])], dim=0).unsqueeze(0)
+    cu_seqlens = F.pad(torch.tensor(seqlens[:-1], device=device, dtype=torch.int32).cumsum(dim=0), (1, 0))
+
+    out_ref = model(x, seq_idx=seq_idx).logits
+    # Only take the last @genlen logits of each sequence
+    out_ref = torch.cat([out_ref[:, cu_seqlens[i + 1] - genlen - 1:cu_seqlens[i + 1] - 1]
+                         for i in range(len(seqlens) - 1)], dim=0)
+
+    # Reference 2: Generate the last @genlen tokens of each sequence in a for loop
+    out_loop = []
+    for input_ids in xs[:-1]:
+        out = model.generate(
+            input_ids=input_ids[:, :-genlen], max_length=input_ids.shape[1], output_scores=True,
+            return_dict_in_generate=True, cg=True, teacher_outputs=input_ids,
+        ).scores
+        out_loop.append(torch.stack(out, dim=1))
+    out_loop = torch.cat(out_loop, dim=0)
+    print(f"Max diff between ref1 and ref2: {(out_loop - out_ref).abs().max()}")
+
+    # Varlen generation
+    input_ids = torch.cat([ids[:, :-genlen] for ids in xs], dim=1)
+    prompt_seqlens = [seqlen - genlen for seqlen in seqlens]
+    cu_seqlens = F.pad(torch.tensor(prompt_seqlens, device=device, dtype=torch.int32).cumsum(dim=0), (1, 0))
+    seq_idx = torch.cat([torch.full((seqlen,), i, dtype=torch.int32, device=device)
+                         for i, seqlen in enumerate(prompt_seqlens)], dim=0).unsqueeze(0)
+    inference_params = InferenceParams(max_seqlen=2048, max_batch_size=len(seqlens))
+
+    # Account for padding
+    offset = genlen * len(seqlens)
+    seq_idx[non_padded_seqlen - offset : padded_seqlen - offset] = -1
+    cu_seqlens[-1] = cu_seqlens[-2]
+
+    scores, sequences = [], []
+    # Both seq_idx and cu_seqlens must be passed in for varlen generation
+    logits = model(input_ids, inference_params=inference_params, seq_idx=seq_idx, cu_seqlens=cu_seqlens).logits
+    logits = rearrange(logits[0, cu_seqlens[1:] - 1], "b d -> b 1 d")
+    scores.append(logits)
+    # In practice we should sample. In this case we take from the teacher_output for testing
+    sampled_tokens = rearrange(torch.stack([ids[0, -genlen] for ids in xs], dim=0), "b -> b 1")
+    sequences.append(sampled_tokens)
+    for i in range(1, genlen):
+        inference_params.seqlen_offset += 1
+        logits = model(sampled_tokens, inference_params=inference_params, num_last_tokens=1).logits
+        scores.append(logits)
+        # In practice we should sample. In this case we take from the teacher_output for testing
+        sampled_tokens = rearrange(torch.stack([ids[0, -genlen + i] for ids in xs], dim=0), "b -> b 1")
+        sequences.append(sampled_tokens)
+    out_varlen = torch.cat(scores, dim=1)
+
+    print(f"Max diff: {(out_varlen[:-1] - out_ref).abs().max()}")
+    assert (out_varlen[:-1] - out_ref).abs().max() < 2 * (out_loop - out_ref).abs().max()


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## What

Adds a weekly scheduled wheel-build pipeline that fans out across:

- **runners**: `ubuntu-22.04`, `ubuntu-22.04-arm`
- **container images**: last 7 `nvcr.io/nvidia/pytorch:YY.MM-py3` images (existing `check_for_ngc_images.sh`)
- **release versions**: last 3 stable upstream tags (new `check_for_releases.sh`, hits `state-spaces/mamba`)

Total: up to **42 jobs** per scheduled run.

Triggers on the new workflow:
- `schedule`: cron `0 6 * * 1` (Mondays 06:00 UTC)
- `workflow_dispatch`: manual run, full matrix

The existing `build_in_container.yml` is left untouched — push/dispatch keep their single-config behavior.

## Example matrix dimensions

```json
{
  "runner":          ["ubuntu-22.04", "ubuntu-22.04-arm"],
  "container-image": ["nvcr.io/nvidia/pytorch:26.04-py3", "..."],
  "release-version": ["v2.3.1", "v2.3.0", "v2.2.6.post3"]
}
```

</details>
